### PR TITLE
Count Triplets That Can Form Two Arrays of Equal XOR

### DIFF
--- a/source/LeetCode.sln.DotSettings
+++ b/source/LeetCode.sln.DotSettings
@@ -19,6 +19,7 @@ known as Yevhenii Yeriemeieiv).&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XC/@EntryIndexedValue">XC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XL/@EntryIndexedValue">XL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XO/@EntryIndexedValue">XO</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XOR/@EntryIndexedValue">XOR</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Eremeev/@EntryIndexedValue">True</s:Boolean>

--- a/source/LeetCode/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/CountTripletsThatCanFormTwoArraysOfEqualXORIterative.cs
+++ b/source/LeetCode/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/CountTripletsThatCanFormTwoArraysOfEqualXORIterative.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.CountTripletsThatCanFormTwoArraysOfEqualXOR;
+
+/// <inheritdoc />
+public class CountTripletsThatCanFormTwoArraysOfEqualXORIterative : ICountTripletsThatCanFormTwoArraysOfEqualXOR
+{
+    /// <summary>
+    ///     Time complexity - O(n^2)
+    /// </summary>
+    /// <param name="arr"></param>
+    /// <returns></returns>
+    public int CountTriplets(int[] arr)
+    {
+        var count = 0;
+
+        var prefixXor = new int[arr.Length + 1];
+
+        for (var i = 0; i < arr.Length; i++)
+        {
+            prefixXor[i + 1] = prefixXor[i] ^ arr[i];
+        }
+
+        for (var i = 0; i < arr.Length; i++)
+        {
+            for (var k = i + 1; k < arr.Length; k++)
+            {
+                if (prefixXor[i] == prefixXor[k + 1])
+                {
+                    count += k - i;
+                }
+            }
+        }
+
+        return count;
+    }
+}

--- a/source/LeetCode/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/ICountTripletsThatCanFormTwoArraysOfEqualXOR.cs
+++ b/source/LeetCode/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/ICountTripletsThatCanFormTwoArraysOfEqualXOR.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.CountTripletsThatCanFormTwoArraysOfEqualXOR;
+
+/// <summary>
+///     https://leetcode.com/problems/count-triplets-that-can-form-two-arrays-of-equal-xor/
+/// </summary>
+public interface ICountTripletsThatCanFormTwoArraysOfEqualXOR
+{
+    int CountTriplets(int[] arr);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/CountTripletsThatCanFormTwoArraysOfEqualXORIterativeTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/CountTripletsThatCanFormTwoArraysOfEqualXORIterativeTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.CountTripletsThatCanFormTwoArraysOfEqualXOR;
+
+namespace LeetCode.Tests.Algorithms.CountTripletsThatCanFormTwoArraysOfEqualXOR;
+
+[TestClass]
+public class CountTripletsThatCanFormTwoArraysOfEqualXORIterativeTests :
+    CountTripletsThatCanFormTwoArraysOfEqualXORTestsBase<CountTripletsThatCanFormTwoArraysOfEqualXORIterative>;

--- a/source/Tests/LeetCode.Tests/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/CountTripletsThatCanFormTwoArraysOfEqualXORTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountTripletsThatCanFormTwoArraysOfEqualXOR/CountTripletsThatCanFormTwoArraysOfEqualXORTestsBase.cs
@@ -1,0 +1,33 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.CountTripletsThatCanFormTwoArraysOfEqualXOR;
+
+namespace LeetCode.Tests.Algorithms.CountTripletsThatCanFormTwoArraysOfEqualXOR;
+
+public abstract class CountTripletsThatCanFormTwoArraysOfEqualXORTestsBase<T>
+    where T : ICountTripletsThatCanFormTwoArraysOfEqualXOR, new()
+{
+    [TestMethod]
+    [DataRow(new[] { 2, 3, 1, 6, 7 }, 4)]
+    [DataRow(new[] { 1, 1, 1, 1, 1 }, 10)]
+    public void CountTriplets_GivenArray_ReturnsExpectedTripletCount(int[] arr, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.CountTriplets(arr);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
I've implemented a solution for the 'Count Triplets That Can Form Two Arrays of Equal XOR' algorithm problem with an iterative approach.

## How Has This Been Tested?
I've covered the code with unit tests.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/eremeeveugene/LeetCode/assets/59287893/4b7e40f3-fe7e-488b-9ad5-83a4b05ccf4b)
