### PR TITLE
Length of Longest Subarray With at Most K Frequency

### DIFF
--- a/source/LeetCode/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/ILengthOfLongestSubarrayWithAtMostKFrequency.cs
+++ b/source/LeetCode/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/ILengthOfLongestSubarrayWithAtMostKFrequency.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+/// <summary>
+///     https://leetcode.com/problems/length-of-longest-subarray-with-at-most-k-frequency/description/
+/// </summary>
+public interface ILengthOfLongestSubarrayWithAtMostKFrequency
+{
+    int MaxSubarrayLength(int[] nums, int k);
+}

--- a/source/LeetCode/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyIterative.cs
+++ b/source/LeetCode/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyIterative.cs
@@ -1,0 +1,54 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+/// <inheritdoc />
+public class LengthOfLongestSubarrayWithAtMostKFrequencyIterative : ILengthOfLongestSubarrayWithAtMostKFrequency
+{
+    /// <summary>
+    ///     Time complexity - O(n^2)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <param name="k"></param>
+    /// <returns></returns>
+    public int MaxSubarrayLength(int[] nums, int k)
+    {
+        var maxLength = 0;
+
+        for (var i = 0; i < nums.Length; i++)
+        {
+            var dictionary = new Dictionary<int, int>();
+
+            for (var j = i; j < nums.Length; j++)
+            {
+                if (dictionary.TryAdd(nums[j], 1))
+                {
+                    continue;
+                }
+
+                if (dictionary[nums[j]] == k)
+                {
+                    maxLength = Math.Max(maxLength, j - i);
+
+                    break;
+                }
+
+                dictionary[nums[j]]++;
+            }
+
+            maxLength = Math.Max(maxLength, dictionary.Select(d => d.Value).Sum());
+        }
+
+        return maxLength;
+    }
+}

--- a/source/LeetCode/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointers.cs
+++ b/source/LeetCode/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointers.cs
@@ -1,0 +1,59 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+/// <inheritdoc />
+public class LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointers : ILengthOfLongestSubarrayWithAtMostKFrequency
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <param name="k"></param>
+    /// <returns></returns>
+    public int MaxSubarrayLength(int[] nums, int k)
+    {
+        var maxLength = 0;
+        var left = 0;
+
+        var frequencyDictionary = new Dictionary<int, int>();
+
+        for (var right = 0; right < nums.Length; right++)
+        {
+            if (frequencyDictionary.TryGetValue(nums[right], out var value))
+            {
+                frequencyDictionary[nums[right]] = ++value;
+            }
+            else
+            {
+                frequencyDictionary[nums[right]] = 1;
+            }
+
+            while (frequencyDictionary[nums[right]] > k)
+            {
+                frequencyDictionary[nums[left]]--;
+
+                if (frequencyDictionary[nums[left]] == 0)
+                {
+                    frequencyDictionary.Remove(nums[left]);
+                }
+
+                left++;
+            }
+
+            maxLength = Math.Max(maxLength, right - left + 1);
+        }
+
+        return maxLength;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyIterativeTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyIterativeTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+namespace LeetCode.Tests.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+[TestClass]
+public class LengthOfLongestSubarrayWithAtMostKFrequencyIterativeTests :
+    LengthOfLongestSubarrayWithAtMostKFrequencyTestsBase<
+        LengthOfLongestSubarrayWithAtMostKFrequencyIterative>;

--- a/source/Tests/LeetCode.Tests/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyTestsBase.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+namespace LeetCode.Tests.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+public abstract class LengthOfLongestSubarrayWithAtMostKFrequencyTestsBase<T>
+    where T : ILengthOfLongestSubarrayWithAtMostKFrequency, new()
+{
+    [TestMethod]
+    [DataRow(new[] { 1 }, 1, 1)]
+    [DataRow(new[] { 1, 11 }, 2, 2)]
+    [DataRow(new[] { 2, 11 }, 1, 2)]
+    [DataRow(new[] { 1, 1, 2 }, 2, 3)]
+    [DataRow(new[] { 1, 2, 3, 1, 2, 3, 1, 2 }, 2, 6)]
+    [DataRow(new[] { 1, 2, 1, 2, 1, 2, 1, 2 }, 1, 2)]
+    [DataRow(new[] { 5, 5, 5, 5, 5, 5, 5 }, 4, 4)]
+    public void MaxSubarrayLength_GivenArrayAndK_ReturnsMaxSubarrayLength(int[] nums, int k, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.MaxSubarrayLength(nums, k);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointersTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LengthOfLongestSubarrayWithAtMostKFrequency/LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointersTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+namespace LeetCode.Tests.Algorithms.LengthOfLongestSubarrayWithAtMostKFrequency;
+
+[TestClass]
+public class LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointersTests :
+    LengthOfLongestSubarrayWithAtMostKFrequencyTestsBase<
+        LengthOfLongestSubarrayWithAtMostKFrequencyTwoPointers>;


### PR DESCRIPTION
# Pull Request

## Description
I've implemented a solution for the 'Length of Longest Subarray With at Most K Frequency' algorithm problem in two ways - using an iterative approach and a two-pointer approach.

## How Has This Been Tested?
I've covered the code with unit tests.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/eremeeveugene/LeetCode-CS/assets/59287893/7926890c-cc28-43e5-941c-707b54d3d485)
