### PR TITLE
Minimum Number of Operations to Make Array XOR Equal to K

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [2958. Length of Longest Subarray With at Most K Frequency](https://leetcode.com/problems/length-of-longest-subarray-with-at-most-k-frequency/description/)
 - [2962. Count Subarrays Where Max Element Appears at Least K Times](https://leetcode.com/problems/count-subarrays-where-max-element-appears-at-least-k-times/description/)
 - [2974. Minimum Number Game](https://leetcode.com/problems/minimum-number-game/description/)
+- [2997. Minimum Number of Operations to Make Array XOR Equal to K](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-xor-equal-to-k/description/)
 - [3005. Count Elements With Maximum Frequency](https://leetcode.com/problems/count-elements-with-maximum-frequency/description/)
 
   </p>

--- a/source/LeetCode/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/IMinimumNumberOfOperationsToMakeArrayXOREqualToK.cs
+++ b/source/LeetCode/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/IMinimumNumberOfOperationsToMakeArrayXOREqualToK.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+/// <summary>
+///     https://leetcode.com/problems/minimum-number-of-operations-to-make-array-xor-equal-to-k/
+/// </summary>
+public interface IMinimumNumberOfOperationsToMakeArrayXOREqualToK
+{
+    int MinOperations(int[] nums, int k);
+}

--- a/source/LeetCode/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBits.cs
+++ b/source/LeetCode/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBits.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+public class MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBits :
+    IMinimumNumberOfOperationsToMakeArrayXOREqualToK
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <param name="k"></param>
+    /// <returns></returns>
+    public int MinOperations(int[] nums, int k)
+    {
+        var xor = nums.Aggregate(0, (current, num) => current ^ num);
+
+        if (xor == k)
+        {
+            return 0;
+        }
+
+        var differingBits = xor ^ k;
+
+        var minOperations = 0;
+
+        while (differingBits != 0)
+        {
+            minOperations += differingBits & 1;
+
+            differingBits >>= 1;
+        }
+
+        return minOperations;
+    }
+}

--- a/source/LeetCode/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeString.cs
+++ b/source/LeetCode/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeString.cs
@@ -1,0 +1,65 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+public class MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeString :
+    IMinimumNumberOfOperationsToMakeArrayXOREqualToK
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <param name="k"></param>
+    /// <returns></returns>
+    public int MinOperations(int[] nums, int k)
+    {
+        var xor = nums.Aggregate(0, (current, num) => current ^ num);
+
+        if (xor == k)
+        {
+            return 0;
+        }
+
+        var minOperations = 0;
+
+        var xorString = Convert.ToString(xor, 2);
+        var kString = Convert.ToString(k, 2);
+
+        var i = 0;
+
+        while (i < xorString.Length || i < kString.Length)
+        {
+            var xorChar = '0';
+            var kChar = '0';
+
+            if (i < xorString.Length)
+            {
+                xorChar = xorString[xorString.Length - 1 - i];
+            }
+
+            if (i < kString.Length)
+            {
+                kChar = kString[kString.Length - 1 - i];
+            }
+
+            if (xorChar != kChar)
+            {
+                minOperations++;
+            }
+
+            i++;
+        }
+
+        return minOperations;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBitsTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBitsTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+namespace LeetCode.Tests.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+[TestClass]
+public class MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBitsTests :
+    MinimumNumberOfOperationsToMakeArrayXOREqualToKTestsBase<
+        MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeBits>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeStringTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeStringTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+namespace LeetCode.Tests.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+[TestClass]
+public class MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeStringTests :
+    MinimumNumberOfOperationsToMakeArrayXOREqualToKTestsBase<
+        MinimumNumberOfOperationsToMakeArrayXOREqualToKIterativeString>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMakeArrayXOREqualToK/MinimumNumberOfOperationsToMakeArrayXOREqualToKTestsBase.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+namespace LeetCode.Tests.Algorithms.MinimumNumberOfOperationsToMakeArrayXOREqualToK;
+
+public abstract class MinimumNumberOfOperationsToMakeArrayXOREqualToKTestsBase<T>
+    where T : IMinimumNumberOfOperationsToMakeArrayXOREqualToK, new()
+{
+    [TestMethod]
+    [DataRow(new[] { 2, 1, 3, 4 }, 1, 2)]
+    [DataRow(new[] { 2, 0, 2, 0 }, 0, 0)]
+    public void MinOperationsToMakeArrayXOREqualToK_GivenArrayAndTargetXOR_ReturnsMinimumOperations(int[] nums, int k,
+        int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.MinOperations(nums, k);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
I've implemented a solution for the 'Minimum Number of Operations to Make Array XOR Equal to K' algorithm problem using an iterative approach.

## How Has This Been Tested?
I've covered the code with unit tests.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/eremeeveugene/LeetCode-CS/assets/59287893/de46b7fc-523e-485a-8b30-9671d8141190)
