### PR TITLE
Find a Corresponding Node of a Binary Tree in a Clone of That Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [1342. Number of Steps to Reduce a Number to Zero](https://leetcode.com/problems/number-of-steps-to-reduce-a-number-to-zero/description/)
 - [1365. How Many Numbers Are Smaller Than the Current Number](https://leetcode.com/problems/how-many-numbers-are-smaller-than-the-current-number/description/)
 - [1370. Increasing Decreasing String](https://leetcode.com/problems/increasing-decreasing-string/description/)
+- [1379. Find a Corresponding Node of a Binary Tree in a Clone of That Tree](https://leetcode.com/problems/find-a-corresponding-node-of-a-binary-tree-in-a-clone-of-that-tree/description/)
 - [1380. Lucky Numbers in a Matrix](https://leetcode.com/problems/lucky-numbers-in-a-matrix/description/)
 - [1404. Number of Steps to Reduce a Number in Binary Representation to One](https://leetcode.com/problems/number-of-steps-to-reduce-a-number-in-binary-representation-to-one/description/)
 - [1408. String Matching in an Array](https://leetcode.com/problems/string-matching-in-an-array/)

--- a/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearch.cs
+++ b/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearch.cs
@@ -1,0 +1,74 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Core.Models;
+
+namespace LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+/// <inheritdoc />
+public class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearch :
+    IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="original"></param>
+    /// <param name="cloned"></param>
+    /// <param name="target"></param>
+    /// <returns></returns>
+    public TreeNode? GetTargetCopy(TreeNode? original, TreeNode? cloned, TreeNode? target)
+    {
+        if (original == null || cloned == null || target == null)
+        {
+            return null;
+        }
+
+        var originalQueue = new Queue<TreeNode>();
+        var clonedQueue = new Queue<TreeNode>();
+
+        originalQueue.Enqueue(original);
+        clonedQueue.Enqueue(cloned);
+
+        while (originalQueue.Count > 0)
+        {
+            var originalNode = originalQueue.Dequeue();
+            var clonedNode = clonedQueue.Dequeue();
+
+            if (originalNode.Equals(target))
+            {
+                return clonedNode;
+            }
+
+            if (originalNode.left != null)
+            {
+                originalQueue.Enqueue(originalNode.left);
+            }
+
+            if (originalNode.right != null)
+            {
+                originalQueue.Enqueue(originalNode.right);
+            }
+
+            if (clonedNode.left != null)
+            {
+                clonedQueue.Enqueue(clonedNode.left);
+            }
+
+            if (clonedNode.right != null)
+            {
+                clonedQueue.Enqueue(clonedNode.right);
+            }
+        }
+
+        return null;
+    }
+}

--- a/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursive.cs
+++ b/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursive.cs
@@ -1,0 +1,44 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Core.Models;
+
+namespace LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+/// <inheritdoc />
+public class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursive :
+    IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n) for a skewed tree, O(log n) for balanced tree
+    /// </summary>
+    /// <param name="original"></param>
+    /// <param name="cloned"></param>
+    /// <param name="target"></param>
+    /// <returns></returns>
+    public TreeNode? GetTargetCopy(TreeNode? original, TreeNode? cloned, TreeNode? target)
+    {
+        if (original == null || cloned == null || target == null)
+        {
+            return null;
+        }
+
+        if (original.Equals(target))
+        {
+            return cloned;
+        }
+
+        var node = GetTargetCopy(original.left, cloned.left, target);
+
+        return node ?? GetTargetCopy(original.right, cloned.right, target);
+    }
+}

--- a/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStack.cs
+++ b/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStack.cs
@@ -1,0 +1,74 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Core.Models;
+
+namespace LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+/// <inheritdoc />
+public class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStack :
+    IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n) for a skewed tree, O(log n) for balanced tree
+    /// </summary>
+    /// <param name="original"></param>
+    /// <param name="cloned"></param>
+    /// <param name="target"></param>
+    /// <returns></returns>
+    public TreeNode? GetTargetCopy(TreeNode? original, TreeNode? cloned, TreeNode? target)
+    {
+        if (original == null || cloned == null || target == null)
+        {
+            return null;
+        }
+
+        var originalStack = new Stack<TreeNode>();
+        var clonedStack = new Stack<TreeNode>();
+
+        originalStack.Push(original);
+        clonedStack.Push(cloned);
+
+        while (originalStack.Count > 0)
+        {
+            var originalNode = originalStack.Pop();
+            var clonedNode = clonedStack.Pop();
+
+            if (originalNode.Equals(target))
+            {
+                return clonedNode;
+            }
+
+            if (originalNode.left != null)
+            {
+                originalStack.Push(originalNode.left);
+            }
+
+            if (originalNode.right != null)
+            {
+                originalStack.Push(originalNode.right);
+            }
+
+            if (clonedNode.left != null)
+            {
+                clonedStack.Push(clonedNode.left);
+            }
+
+            if (clonedNode.right != null)
+            {
+                clonedStack.Push(clonedNode.right);
+            }
+        }
+
+        return null;
+    }
+}

--- a/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree.cs
+++ b/source/LeetCode/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree.cs
@@ -1,0 +1,22 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Core.Models;
+
+namespace LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+/// <summary>
+///     https://leetcode.com/problems/find-a-corresponding-node-of-a-binary-tree-in-a-clone-of-that-tree/
+/// </summary>
+public interface IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree
+{
+    TreeNode? GetTargetCopy(TreeNode? original, TreeNode? cloned, TreeNode? target);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearchTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearchTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+namespace LeetCode.Tests.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+[TestClass]
+public class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearchTests :
+    FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase<
+        FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeBreadthFirstSearch>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursiveTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursiveTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+namespace LeetCode.Tests.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+[TestClass]
+public class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursiveTests :
+    FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase<
+        FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchRecursive>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStackTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStackTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+namespace LeetCode.Tests.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+[TestClass]
+public class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStackTests :
+    FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase<
+        FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeDepthFirstSearchStack>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase.cs
@@ -1,0 +1,98 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+using LeetCode.Core.Helpers;
+using LeetCode.Core.Models;
+using LeetCode.Tests.Base.Extensions;
+
+namespace LeetCode.Tests.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
+
+public abstract class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase<T>
+    where T : IFindCorrespondingNodeOfBinaryTreeInCloneOfThatTree, new()
+{
+    [TestMethod]
+    [DataRow("[7]", 7, 7)]
+    [DataRow("[7,4,3,null,null,6,19]", 3, 3)]
+    [DataRow("[8,null,6,null,5,null,4,null,3,null,2,null,1]", 4, 4)]
+    public void GetTargetCopy_GivenOriginalAndClonedTree_ReturnsCorrespondingNode(string treeJsonArray, int targetValue,
+        int expectedResultValue)
+    {
+        // Arrange
+        var treeArray = JsonHelper<int?>.JsonArrayToList(treeJsonArray);
+        var original = TreeNode.BuildTree(treeArray) ?? throw new InvalidOperationException();
+        var cloned = TreeNode.BuildTree(treeArray) ?? throw new InvalidOperationException();
+
+        TreeNode? target = null;
+
+        var targetStack = new Stack<TreeNode>();
+
+        targetStack.Push(original);
+
+        while (targetStack.Count > 0)
+        {
+            var node = targetStack.Pop();
+
+            if (node.val == targetValue)
+            {
+                target = node;
+
+                break;
+            }
+
+            if (node.left != null)
+            {
+                targetStack.Push(node.left);
+            }
+
+            if (node.right != null)
+            {
+                targetStack.Push(node.right);
+            }
+        }
+
+        TreeNode? expectedResult = null;
+
+        var expectedResultStack = new Stack<TreeNode>();
+
+        expectedResultStack.Push(cloned);
+
+        while (expectedResultStack.Count > 0)
+        {
+            var node = expectedResultStack.Pop();
+
+            if (node.val == expectedResultValue)
+            {
+                expectedResult = node;
+
+                break;
+            }
+
+            if (node.left != null)
+            {
+                expectedResultStack.Push(node.left);
+            }
+
+            if (node.right != null)
+            {
+                expectedResultStack.Push(node.right);
+            }
+        }
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.GetTargetCopy(original, cloned, target);
+
+        // Assert
+        TreeNodeAssert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Find a Corresponding Node of a Binary Tree in a Clone of That Tree' algorithm problem in three ways using a depth-first search with stack, a recursive depth-first search, and a breadth-first approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/7433675c-a9fe-41ff-a378-ed60f4656e1e)
