### PR TITLE
Most Stones Removed with Same Row or Column

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [912. Sort an Array](https://leetcode.com/problems/sort-an-array/description/)
 - [930. Binary Subarrays With Sum](https://leetcode.com/problems/binary-subarrays-with-sum/description/)
 - [938. Range Sum of BST](https://leetcode.com/problems/range-sum-of-bst/description/)
+- [947. Most Stones Removed with Same Row or Column](https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/description/)
 - [945. Minimum Increment to Make Array Unique](https://leetcode.com/problems/minimum-increment-to-make-array-unique/description/)
 - [948. Bag of Tokens](https://leetcode.com/problems/bag-of-tokens/description/)
 - [950. Reveal Cards In Increasing Order](https://leetcode.com/problems/reveal-cards-in-increasing-order/description/)

--- a/source/LeetCode/Algorithms/MostStonesRemovedWithSameRowOrColumn/IMostStonesRemovedWithSameRowOrColumn.cs
+++ b/source/LeetCode/Algorithms/MostStonesRemovedWithSameRowOrColumn/IMostStonesRemovedWithSameRowOrColumn.cs
@@ -1,0 +1,9 @@
+﻿namespace LeetCode.Algorithms.MostStonesRemovedWithSameRowOrColumn;
+
+/// <summary>
+///     https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/description/
+/// </summary>
+public interface IMostStonesRemovedWithSameRowOrColumn
+{
+    int RemoveStones(int[][] stones);
+}

--- a/source/LeetCode/Algorithms/MostStonesRemovedWithSameRowOrColumn/MostStonesRemovedWithSameRowOrColumnUnionFind.cs
+++ b/source/LeetCode/Algorithms/MostStonesRemovedWithSameRowOrColumn/MostStonesRemovedWithSameRowOrColumnUnionFind.cs
@@ -1,0 +1,70 @@
+﻿namespace LeetCode.Algorithms.MostStonesRemovedWithSameRowOrColumn;
+
+/// <inheritdoc />
+public class MostStonesRemovedWithSameRowOrColumnUnionFind : IMostStonesRemovedWithSameRowOrColumn
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="stones"></param>
+    /// <returns></returns>
+    public int RemoveStones(int[][] stones)
+    {
+        var unionFind = new UnionFind(20002);
+
+        foreach (var stone in stones)
+        {
+            unionFind.Union(stone[0], stone[1] + 10001);
+        }
+
+        return stones.Length - unionFind.ComponentCount;
+    }
+
+    private class UnionFind
+    {
+        private readonly int[] _parent;
+        private readonly HashSet<int> _uniqueNodes = [];
+
+        public UnionFind(int n)
+        {
+            _parent = new int[n];
+
+            Array.Fill(_parent, -1);
+        }
+
+        public int ComponentCount { get; private set; }
+
+        private int Find(int node)
+        {
+            if (!_uniqueNodes.Contains(node))
+            {
+                ComponentCount++;
+
+                _uniqueNodes.Add(node);
+            }
+
+            if (_parent[node] == -1)
+            {
+                return node;
+            }
+
+            return _parent[node] = Find(_parent[node]);
+        }
+
+        public void Union(int x, int y)
+        {
+            var rootX = Find(x);
+            var rootY = Find(y);
+
+            if (rootX == rootY)
+            {
+                return;
+            }
+
+            _parent[rootX] = rootY;
+
+            ComponentCount--;
+        }
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/MostStonesRemovedWithSameRowOrColumn/MostStonesRemovedWithSameRowOrColumnTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MostStonesRemovedWithSameRowOrColumn/MostStonesRemovedWithSameRowOrColumnTestsBase.cs
@@ -1,0 +1,32 @@
+﻿using LeetCode.Algorithms.MostStonesRemovedWithSameRowOrColumn;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.MostStonesRemovedWithSameRowOrColumn;
+
+public abstract class MostStonesRemovedWithSameRowOrColumnTestsBase<T>
+    where T : IMostStonesRemovedWithSameRowOrColumn, new()
+{
+    [TestMethod]
+    [DataRow("[[0,0]]", 0)]
+    [DataRow("[[0,0],[2,2],[10000,2]]", 1)]
+    [DataRow("[[0,0],[0,2],[1,1],[2,0],[2,2]]", 3)]
+    [DataRow("[[0,0],[0,1],[1,0],[1,2],[2,1],[2,2]]", 5)]
+    [DataRow("[[0,0],[1,0],[2,0],[1,1],[1,2],[2,2]]", 5)]
+    [DataRow("[[0,0],[0,1],[0,2],[1,4],[1,5],[2,4],[2,6]]", 5)]
+    [DataRow("[[0,0],[0,1],[0,2],[0,3],[1,4],[1,5],[2,4],[2,6]]", 6)]
+    [DataRow("[[0,0],[0,1],[1,0],[1,2],[2,0],[2,3],[3,0],[3,4]]", 7)]
+    [DataRow("[[0,5],[1,5],[2,5],[3,5],[0,4],[0,6],[1,3],[1,7],[2,2],[2,8],[3,1],[3,9]]", 11)]
+    public void RemoveStones_WithGridOfStones_ReturnsMaxRemovableStones(string stonesJsonArray, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        var stones = JsonHelper<int>.JsonArrayToJaggedArray(stonesJsonArray);
+
+        // Act
+        var actualResult = solution.RemoveStones(stones);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/MostStonesRemovedWithSameRowOrColumn/MostStonesRemovedWithSameRowOrColumnUnionFindTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MostStonesRemovedWithSameRowOrColumn/MostStonesRemovedWithSameRowOrColumnUnionFindTests.cs
@@ -1,0 +1,7 @@
+﻿using LeetCode.Algorithms.MostStonesRemovedWithSameRowOrColumn;
+
+namespace LeetCode.Tests.Algorithms.MostStonesRemovedWithSameRowOrColumn;
+
+[TestClass]
+public class MostStonesRemovedWithSameRowOrColumnUnionFindTests : MostStonesRemovedWithSameRowOrColumnTestsBase<
+    MostStonesRemovedWithSameRowOrColumnUnionFind>;


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Most Stones Removed with Same Row or Column' algorithm problem using a union-find approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/dc661d23-8fa4-4b22-89e5-1b1a9ce57052)
