### PR TITLE
Find the Longest Substring Containing Vowels in Even Counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [1365. How Many Numbers Are Smaller Than the Current Number](https://leetcode.com/problems/how-many-numbers-are-smaller-than-the-current-number/description/)
 - [1367. Linked List in Binary Tree](https://leetcode.com/problems/linked-list-in-binary-tree/description/)
 - [1370. Increasing Decreasing String](https://leetcode.com/problems/increasing-decreasing-string/description/)
+- [1371. Find the Longest Substring Containing Vowels in Even Counts](https://leetcode.com/problems/find-the-longest-substring-containing-vowels-in-even-counts/description/)
 - [1379. Find a Corresponding Node of a Binary Tree in a Clone of That Tree](https://leetcode.com/problems/find-a-corresponding-node-of-a-binary-tree-in-a-clone-of-that-tree/description/)
 - [1380. Lucky Numbers in a Matrix](https://leetcode.com/problems/lucky-numbers-in-a-matrix/description/)
 - [1404. Number of Steps to Reduce a Number in Binary Representation to One](https://leetcode.com/problems/number-of-steps-to-reduce-a-number-in-binary-representation-to-one/description/)

--- a/source/LeetCode.sln.DotSettings
+++ b/source/LeetCode.sln.DotSettings
@@ -27,6 +27,7 @@ known as Yevhenii Yeriemeieiv).&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XO/@EntryIndexedValue">XO</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XOR/@EntryIndexedValue">XOR</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002ECodeCleanup_002EFileHeader_002EFileHeaderSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bitmasking/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Comparers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=deadends/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Defanging/@EntryIndexedValue">True</s:Boolean>

--- a/source/LeetCode/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/FindTheLongestSubstringContainingVowelsInEvenCountsBitmasking.cs
+++ b/source/LeetCode/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/FindTheLongestSubstringContainingVowelsInEvenCountsBitmasking.cs
@@ -1,0 +1,58 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindTheLongestSubstringContainingVowelsInEvenCounts;
+
+/// <inheritdoc />
+public class
+    FindTheLongestSubstringContainingVowelsInEvenCountsBitmasking : IFindTheLongestSubstringContainingVowelsInEvenCounts
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="s"></param>
+    /// <returns></returns>
+    public int FindTheLongestSubstring(string s)
+    {
+        var vowelXorValues = new int['z' - 'a' + 1];
+
+        vowelXorValues['a' - 'a'] = 1;
+        vowelXorValues['e' - 'a'] = 2;
+        vowelXorValues['i' - 'a'] = 4;
+        vowelXorValues['o' - 'a'] = 8;
+        vowelXorValues['u' - 'a'] = 16;
+
+        var xorStateFirstIndex = new int[32];
+
+        for (var i = 0; i < 32; i++)
+        {
+            xorStateFirstIndex[i] = -1;
+        }
+
+        var longestSubstringLength = 0;
+        var currentXorState = 0;
+
+        for (var i = 0; i < s.Length; i++)
+        {
+            currentXorState ^= vowelXorValues[s[i] - 'a'];
+
+            if (xorStateFirstIndex[currentXorState] == -1 && currentXorState != 0)
+            {
+                xorStateFirstIndex[currentXorState] = i;
+            }
+
+            longestSubstringLength = Math.Max(longestSubstringLength, i - xorStateFirstIndex[currentXorState]);
+        }
+
+        return longestSubstringLength;
+    }
+}

--- a/source/LeetCode/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/IFindTheLongestSubstringContainingVowelsInEvenCounts.cs
+++ b/source/LeetCode/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/IFindTheLongestSubstringContainingVowelsInEvenCounts.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindTheLongestSubstringContainingVowelsInEvenCounts;
+
+/// <summary>
+///     https://leetcode.com/problems/find-the-longest-substring-containing-vowels-in-even-counts/
+/// </summary>
+public interface IFindTheLongestSubstringContainingVowelsInEvenCounts
+{
+    int FindTheLongestSubstring(string s);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/FindTheLongestSubstringContainingVowelsInEvenCountsBitmaskingTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/FindTheLongestSubstringContainingVowelsInEvenCountsBitmaskingTests.cs
@@ -1,0 +1,19 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindTheLongestSubstringContainingVowelsInEvenCounts;
+
+namespace LeetCode.Tests.Algorithms.FindTheLongestSubstringContainingVowelsInEvenCounts;
+
+[TestClass]
+public class FindTheLongestSubstringContainingVowelsInEvenCountsBitmaskingTests :
+    FindTheLongestSubstringContainingVowelsInEvenCountsTestsBase<
+        FindTheLongestSubstringContainingVowelsInEvenCountsBitmasking>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/FindTheLongestSubstringContainingVowelsInEvenCountsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTheLongestSubstringContainingVowelsInEvenCounts/FindTheLongestSubstringContainingVowelsInEvenCountsTestsBase.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindTheLongestSubstringContainingVowelsInEvenCounts;
+
+namespace LeetCode.Tests.Algorithms.FindTheLongestSubstringContainingVowelsInEvenCounts;
+
+public abstract class FindTheLongestSubstringContainingVowelsInEvenCountsTestsBase<T>
+    where T : IFindTheLongestSubstringContainingVowelsInEvenCounts, new()
+{
+    [TestMethod]
+    [DataRow("bcbcbc", 6)]
+    [DataRow("leetcodeisgreat", 5)]
+    [DataRow("eleetminicoworoep", 13)]
+    public void FindTheLongestSubstring_GivenString_ReturnsLongestSubstringLength(string s, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.FindTheLongestSubstring(s);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Find the Longest Substring Containing Vowels in Even Counts' algorithm problem using a bitmasking approach. 

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/1fdcd398-0545-466a-88bc-e3130ab6dae5)
