### PR TITLE
Count Number of Maximum Bitwise-OR Subsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [2022. Convert 1D Array Into 2D Array](https://leetcode.com/problems/convert-1d-array-into-2d-array/description/)
 - [2028. Find Missing Observations](https://leetcode.com/problems/find-missing-observations/description/)
 - [2037. Minimum Number of Moves to Seat Everyone](https://leetcode.com/problems/minimum-number-of-moves-to-seat-everyone/description/)
+- [2044. Count Number of Maximum Bitwise-OR Subsets](https://leetcode.com/problems/count-number-of-maximum-bitwise-or-subsets/description/)
 - [2053. Kth Distinct String in an Array](https://leetcode.com/problems/kth-distinct-string-in-an-array/description/)
 - [2058. Find the Minimum and Maximum Number of Nodes Between Critical Points](https://leetcode.com/problems/find-the-minimum-and-maximum-number-of-nodes-between-critical-points/description/)
 - [2073. Time Needed to Buy Tickets](https://leetcode.com/problems/time-needed-to-buy-tickets/description/)

--- a/source/LeetCode.sln.DotSettings
+++ b/source/LeetCode.sln.DotSettings
@@ -22,6 +22,7 @@ known as Yevhenii Yeriemeieiv).&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IX/@EntryIndexedValue">IX</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=KMP/@EntryIndexedValue">KMP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LPS/@EntryIndexedValue">LPS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OR/@EntryIndexedValue">OR</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XC/@EntryIndexedValue">XC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XL/@EntryIndexedValue">XL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=XO/@EntryIndexedValue">XO</s:String>

--- a/source/LeetCode/Algorithms/CountNumberOfMaximumBitwiseORSubsets/CountNumberOfMaximumBitwiseORSubsetsBacktracking.cs
+++ b/source/LeetCode/Algorithms/CountNumberOfMaximumBitwiseORSubsets/CountNumberOfMaximumBitwiseORSubsetsBacktracking.cs
@@ -1,0 +1,51 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.CountNumberOfMaximumBitwiseORSubsets;
+
+/// <inheritdoc />
+public class CountNumberOfMaximumBitwiseORSubsetsBacktracking : ICountNumberOfMaximumBitwiseORSubsets
+{
+    /// <summary>
+    ///     Time complexity - O(2^n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <returns></returns>
+    public int CountMaxOrSubsets(int[] nums)
+    {
+        var maxOr = 0;
+        var count = 0;
+
+        maxOr = nums.Aggregate(maxOr, (current, num) => current | num);
+
+        CountMaxOrSubsetsHelper(nums, 0, 0, ref maxOr, ref count);
+
+        return count;
+    }
+
+    private static void CountMaxOrSubsetsHelper(int[] nums, int index, int currentOr, ref int maxOr, ref int count)
+    {
+        if (index == nums.Length)
+        {
+            if (currentOr == maxOr)
+            {
+                count++;
+            }
+
+            return;
+        }
+
+        CountMaxOrSubsetsHelper(nums, index + 1, currentOr | nums[index], ref maxOr, ref count);
+
+        CountMaxOrSubsetsHelper(nums, index + 1, currentOr, ref maxOr, ref count);
+    }
+}

--- a/source/LeetCode/Algorithms/CountNumberOfMaximumBitwiseORSubsets/ICountNumberOfMaximumBitwiseORSubsets.cs
+++ b/source/LeetCode/Algorithms/CountNumberOfMaximumBitwiseORSubsets/ICountNumberOfMaximumBitwiseORSubsets.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.CountNumberOfMaximumBitwiseORSubsets;
+
+/// <summary>
+///     https://leetcode.com/problems/count-number-of-maximum-bitwise-or-subsets/description/
+/// </summary>
+public interface ICountNumberOfMaximumBitwiseORSubsets
+{
+    int CountMaxOrSubsets(int[] nums);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/CountNumberOfMaximumBitwiseORSubsets/CountNumberOfMaximumBitwiseORSubsetsBacktrackingTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountNumberOfMaximumBitwiseORSubsets/CountNumberOfMaximumBitwiseORSubsetsBacktrackingTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.CountNumberOfMaximumBitwiseORSubsets;
+
+namespace LeetCode.Tests.Algorithms.CountNumberOfMaximumBitwiseORSubsets;
+
+[TestClass]
+public class CountNumberOfMaximumBitwiseORSubsetsBacktrackingTests :
+    CountNumberOfMaximumBitwiseORSubsetsTestsBase<CountNumberOfMaximumBitwiseORSubsetsBacktracking>;

--- a/source/Tests/LeetCode.Tests/Algorithms/CountNumberOfMaximumBitwiseORSubsets/CountNumberOfMaximumBitwiseORSubsetsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountNumberOfMaximumBitwiseORSubsets/CountNumberOfMaximumBitwiseORSubsetsTestsBase.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2024 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.CountNumberOfMaximumBitwiseORSubsets;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.CountNumberOfMaximumBitwiseORSubsets;
+
+public abstract class CountNumberOfMaximumBitwiseORSubsetsTestsBase<T>
+    where T : ICountNumberOfMaximumBitwiseORSubsets, new()
+{
+    [TestMethod]
+    [DataRow("[3,1]", 2)]
+    [DataRow("[2,2,2]", 7)]
+    [DataRow("[3,2,1,5]", 6)]
+    public void CountMaxOrSubsets_GivenArrayOfIntegers_ReturnsNumberOfMaxOrSubsets(string numsJsonArray,
+        int expectedResult)
+    {
+        // Arrange
+        var nums = JsonHelper<int>.DeserializeToArray(numsJsonArray);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.CountMaxOrSubsets(nums);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Count Number of Maximum Bitwise-OR Subsets' algorithm problem using a backtracking approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/0e16bfb3-c32d-4a2c-88b0-24b51db1a9e8)
