### PR TITLE
Find the Prefix Common Array of Two Arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [2641. Cousins in Binary Tree II](https://leetcode.com/problems/cousins-in-binary-tree-ii/description/)
 - [2651. Calculate Delayed Arrival Time](https://leetcode.com/problems/calculate-delayed-arrival-time/description/)
 - [2652. Sum Multiples](https://leetcode.com/problems/sum-multiples/description/)
+- [2657. Find the Prefix Common Array of Two Arrays](https://leetcode.com/problems/find-the-prefix-common-array-of-two-arrays/description/)
 - [2678. Number of Senior Citizens](https://leetcode.com/problems/number-of-senior-citizens/description/)
 - [2684. Maximum Number of Moves in a Grid](https://leetcode.com/problems/maximum-number-of-moves-in-a-grid/description/)
 - [2696. Minimum String Length After Removing Substrings](https://leetcode.com/problems/minimum-string-length-after-removing-substrings/description/)

--- a/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysFrequencyArray.cs
+++ b/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysFrequencyArray.cs
@@ -1,0 +1,51 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+/// <inheritdoc />
+public class FindThePrefixCommonArrayOfTwoArraysFrequencyArray : IFindThePrefixCommonArrayOfTwoArrays
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="a"></param>
+    /// <param name="b"></param>
+    /// <returns></returns>
+    public int[] FindThePrefixCommonArray(int[] a, int[] b)
+    {
+        var result = new int[a.Length];
+        var frequencyArray = new int[a.Length];
+        var count = 0;
+
+        for (var i = 0; i < a.Length; i++)
+        {
+            frequencyArray[a[i] - 1]++;
+
+            if (frequencyArray[a[i] - 1] == 2)
+            {
+                count++;
+            }
+
+            frequencyArray[b[i] - 1]++;
+
+            if (frequencyArray[b[i] - 1] == 2)
+            {
+                count++;
+            }
+
+            result[i] = count;
+        }
+
+        return result;
+    }
+}

--- a/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysHashSet.cs
+++ b/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysHashSet.cs
@@ -1,0 +1,47 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+/// <inheritdoc />
+public class FindThePrefixCommonArrayOfTwoArraysHashSet : IFindThePrefixCommonArrayOfTwoArrays
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="a"></param>
+    /// <param name="b"></param>
+    /// <returns></returns>
+    public int[] FindThePrefixCommonArray(int[] a, int[] b)
+    {
+        var result = new int[a.Length];
+        var seenHashSet = new HashSet<int>();
+        var commonCount = 0;
+
+        for (var i = 0; i < a.Length; i++)
+        {
+            if (!seenHashSet.Add(a[i]))
+            {
+                commonCount++;
+            }
+
+            if (!seenHashSet.Add(b[i]))
+            {
+                commonCount++;
+            }
+
+            result[i] = commonCount;
+        }
+
+        return result;
+    }
+}

--- a/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysHashSet.cs
+++ b/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysHashSet.cs
@@ -25,21 +25,21 @@ public class FindThePrefixCommonArrayOfTwoArraysHashSet : IFindThePrefixCommonAr
     {
         var result = new int[a.Length];
         var seenHashSet = new HashSet<int>();
-        var commonCount = 0;
+        var count = 0;
 
         for (var i = 0; i < a.Length; i++)
         {
             if (!seenHashSet.Add(a[i]))
             {
-                commonCount++;
+                count++;
             }
 
             if (!seenHashSet.Add(b[i]))
             {
-                commonCount++;
+                count++;
             }
 
-            result[i] = commonCount;
+            result[i] = count;
         }
 
         return result;

--- a/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/IFindThePrefixCommonArrayOfTwoArrays.cs
+++ b/source/LeetCode/Algorithms/FindThePrefixCommonArrayOfTwoArrays/IFindThePrefixCommonArrayOfTwoArrays.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+/// <summary>
+///     https://leetcode.com/problems/find-the-prefix-common-array-of-two-arrays/description/
+/// </summary>
+public interface IFindThePrefixCommonArrayOfTwoArrays
+{
+    int[] FindThePrefixCommonArray(int[] a, int[] b);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysFrequencyArrayTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysFrequencyArrayTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+namespace LeetCode.Tests.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+[TestClass]
+public class FindThePrefixCommonArrayOfTwoArraysFrequencyArrayTests :
+    FindThePrefixCommonArrayOfTwoArraysTestsBase<FindThePrefixCommonArrayOfTwoArraysFrequencyArray>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysHashSetTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysHashSetTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+namespace LeetCode.Tests.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+[TestClass]
+public class FindThePrefixCommonArrayOfTwoArraysHashSetTests :
+    FindThePrefixCommonArrayOfTwoArraysTestsBase<FindThePrefixCommonArrayOfTwoArraysHashSet>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysTestsBase.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.FindThePrefixCommonArrayOfTwoArrays;
+
+public abstract class FindThePrefixCommonArrayOfTwoArraysTestsBase<T>
+    where T : IFindThePrefixCommonArrayOfTwoArrays, new()
+{
+    [TestMethod]
+    [DataRow("[2,3,1]", "[3,1,2]", "[0,1,3]")]
+    [DataRow("[1,3,2,4]", "[3,1,2,4]", "[0,2,3,4]")]
+    public void Test(string aJsonArray, string bJsonArray, string expectedResultJsonArray)
+    {
+        // Arrange
+        var a = JsonHelper<int>.DeserializeToArray(aJsonArray);
+        var b = JsonHelper<int>.DeserializeToArray(bJsonArray);
+        var expectedResult = JsonHelper<int>.DeserializeToArray(expectedResultJsonArray);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.FindThePrefixCommonArray(a, b);
+
+        // Assert
+        CollectionAssert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Find the Prefix Common Array of Two Arrays' algorithm problem using a frequency array and a hash set approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a33f8084-8411-4a09-9c5f-4e2b260554de)
