### PR TITLE
Max Sum of a Pair With Equal Sum of Digits

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: .NET CI/CD
+name: .NET
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [2326. Spiral Matrix IV](https://leetcode.com/problems/spiral-matrix-iv/description/)
 - [2331. Evaluate Boolean Binary Tree](https://leetcode.com/problems/evaluate-boolean-binary-tree/description/)
 - [2337. Move Pieces to Obtain a String](https://leetcode.com/problems/move-pieces-to-obtain-a-string/description/)
+- [2342. Max Sum of a Pair With Equal Sum of Digits](https://leetcode.com/problems/max-sum-of-a-pair-with-equal-sum-of-digits/description/)
 - [2349. Design a Number Container System](https://leetcode.com/problems/design-a-number-container-system/description/)
 - [2364. Count Number of Bad Pairs](https://leetcode.com/problems/count-number-of-bad-pairs/description/)
 - [2370. Longest Ideal Subsequence](https://leetcode.com/problems/longest-ideal-subsequence/description/)

--- a/source/LeetCode/Algorithms/MaxSumOfPairWithEqualSumOfDigits/IMaxSumOfPairWithEqualSumOfDigits.cs
+++ b/source/LeetCode/Algorithms/MaxSumOfPairWithEqualSumOfDigits/IMaxSumOfPairWithEqualSumOfDigits.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+/// <summary>
+///     https://leetcode.com/problems/max-sum-of-a-pair-with-equal-sum-of-digits/description/
+/// </summary>
+public interface IMaxSumOfPairWithEqualSumOfDigits
+{
+    int MaximumSum(int[] nums);
+}

--- a/source/LeetCode/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsArray.cs
+++ b/source/LeetCode/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsArray.cs
@@ -1,0 +1,65 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+/// <inheritdoc />
+public class MaxSumOfPairWithEqualSumOfDigitsDictionary : IMaxSumOfPairWithEqualSumOfDigits
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <returns></returns>
+    public int MaximumSum(int[] nums)
+    {
+        var maximumSum = -1;
+        var maxNums = new int[82];
+        var secondMaxNums = new int[82];
+
+        foreach (var num in nums)
+        {
+            var digitSum = GetDigitSum(num);
+
+            if (num > maxNums[digitSum])
+            {
+                secondMaxNums[digitSum] = maxNums[digitSum];
+                maxNums[digitSum] = num;
+            }
+            else if (num > secondMaxNums[digitSum])
+            {
+                secondMaxNums[digitSum] = num;
+            }
+
+            if (secondMaxNums[digitSum] > 0)
+            {
+                maximumSum = Math.Max(maximumSum, maxNums[digitSum] + secondMaxNums[digitSum]);
+            }
+        }
+
+        return maximumSum;
+    }
+
+    private static int GetDigitSum(int num)
+    {
+        var digitSum = 0;
+
+        while (num > 0)
+        {
+            digitSum += num % 10;
+
+            num /= 10;
+        }
+
+        return digitSum;
+    }
+}

--- a/source/LeetCode/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsDictionary.cs
+++ b/source/LeetCode/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsDictionary.cs
@@ -1,0 +1,73 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+/// <inheritdoc />
+public class MaxSumOfPairWithEqualSumOfDigits1 : IMaxSumOfPairWithEqualSumOfDigits
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <returns></returns>
+    public int MaximumSum(int[] nums)
+    {
+        var maximumSum = -1;
+        var dictionary = new Dictionary<int, (int Num1, int Num2)>();
+
+        foreach (var num in nums)
+        {
+            var digitSum = GetDigitSum(num);
+
+            if (dictionary.TryGetValue(digitSum, out var digits))
+            {
+                var num1 = digits.Num1;
+                var num2 = digits.Num2;
+
+                if (num > digits.Num1)
+                {
+                    num2 = num1;
+                    num1 = num;
+                }
+                else if (num > num2)
+                {
+                    num2 = num;
+                }
+
+                maximumSum = Math.Max(maximumSum, num1 + num2);
+
+                dictionary[digitSum] = (num1, num2);
+            }
+            else
+            {
+                dictionary.Add(digitSum, (num, 0));
+            }
+        }
+
+        return maximumSum;
+    }
+
+    private static int GetDigitSum(int num)
+    {
+        var digitSum = 0;
+
+        while (num > 0)
+        {
+            digitSum += num % 10;
+
+            num /= 10;
+        }
+
+        return digitSum;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsArrayTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsArrayTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+namespace LeetCode.Tests.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+[TestClass]
+public class MaxSumOfPairWithEqualSumOfDigitsArrayTests :
+    MaxSumOfPairWithEqualSumOfDigitsTestsBase<MaxSumOfPairWithEqualSumOfDigits1>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsDictionaryTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsDictionaryTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+namespace LeetCode.Tests.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+[TestClass]
+public class MaxSumOfPairWithEqualSumOfDigitsDictionaryTests :
+    MaxSumOfPairWithEqualSumOfDigitsTestsBase<MaxSumOfPairWithEqualSumOfDigitsDictionary>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaxSumOfPairWithEqualSumOfDigits/MaxSumOfPairWithEqualSumOfDigitsTestsBase.cs
@@ -1,0 +1,35 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.MaxSumOfPairWithEqualSumOfDigits;
+
+public abstract class MaxSumOfPairWithEqualSumOfDigitsTestsBase<T> where T : IMaxSumOfPairWithEqualSumOfDigits, new()
+{
+    [TestMethod]
+    [DataRow("[18,43,36,13,7]", 54)]
+    [DataRow("[10,12,19,14]", -1)]
+    public void MaximumSum_GivenArrayOfNumbers_ReturnsLargestSumOfDigitPairs(string numsJsonArray, int expectedResult)
+    {
+        // Arrange
+        var nums = JsonHelper<int>.DeserializeToArray(numsJsonArray);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.MaximumSum(nums);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Max Sum of a Pair With Equal Sum of Digits' algorithm problem using a dictionary and an array approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c72a945f-8380-45dc-a490-09cbb2207d31)
