### PR TITLE
Number of Sub-arrays With Odd Sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [1514. Path with Maximum Probability](https://leetcode.com/problems/path-with-maximum-probability/description/)
 - [1518. Water Bottles](https://leetcode.com/problems/water-bottles/description/)
 - [1523. Count Odd Numbers in an Interval Range](https://leetcode.com/problems/count-odd-numbers-in-an-interval-range/description/)
+- [1524. Number of Sub-arrays With Odd Sum](https://leetcode.com/problems/number-of-sub-arrays-with-odd-sum/description/)
 - [1528. Shuffle String](https://leetcode.com/problems/shuffle-string/description/)
 - [1530. Number of Good Leaf Nodes Pairs](https://leetcode.com/problems/number-of-good-leaf-nodes-pairs/description/)
 - [1544. Make The String Great](https://leetcode.com/problems/make-the-string-great/description/)

--- a/source/LeetCode/Algorithms/NumberOfSubArraysWithOddSum/INumberOfSubArraysWithOddSum.cs
+++ b/source/LeetCode/Algorithms/NumberOfSubArraysWithOddSum/INumberOfSubArraysWithOddSum.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfSubArraysWithOddSum;
+
+/// <summary>
+///     https://leetcode.com/problems/number-of-sub-arrays-with-odd-sum/description/
+/// </summary>
+public interface INumberOfSubArraysWithOddSum
+{
+    int NumOfSubarrays(int[] arr);
+}

--- a/source/LeetCode/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumBruteForce.cs
+++ b/source/LeetCode/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumBruteForce.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfSubArraysWithOddSum;
+
+/// <inheritdoc />
+public class NumberOfSubArraysWithOddSumBruteForce : INumberOfSubArraysWithOddSum
+{
+    private const int Mod = (int)(1e9 + 7);
+
+    /// <summary>
+    ///     Time complexity - O(n^2)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="arr"></param>
+    /// <returns></returns>
+    public int NumOfSubarrays(int[] arr)
+    {
+        var count = 0;
+
+        for (var i = 0; i < arr.Length; i++)
+        {
+            var currentSum = 0;
+
+            for (var j = i; j < arr.Length; j++)
+            {
+                currentSum += arr[j];
+
+                if (currentSum % 2 != 0)
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count % Mod;
+    }
+}

--- a/source/LeetCode/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumPrefixSum.cs
+++ b/source/LeetCode/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumPrefixSum.cs
@@ -1,0 +1,54 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfSubArraysWithOddSum;
+
+/// <inheritdoc />
+public class NumberOfSubArraysWithOddSumPrefixSum : INumberOfSubArraysWithOddSum
+{
+    private const int Mod = (int)(1e9 + 7);
+
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="arr"></param>
+    /// <returns></returns>
+    public int NumOfSubarrays(int[] arr)
+    {
+        var count = 0;
+        var oddCount = 0;
+        var evenCount = 1;
+        var prefixSum = 0;
+
+        foreach (var num in arr)
+        {
+            prefixSum += num;
+
+            if (prefixSum % 2 == 0)
+            {
+                count += oddCount;
+
+                evenCount++;
+            }
+            else
+            {
+                count += evenCount;
+
+                oddCount++;
+            }
+
+            count %= Mod;
+        }
+
+        return count;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumBruteForceTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumBruteForceTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfSubArraysWithOddSum;
+
+namespace LeetCode.Tests.Algorithms.NumberOfSubArraysWithOddSum;
+
+[TestClass]
+public class NumberOfSubArraysWithOddSumBruteForceTests :
+    NumberOfSubArraysWithOddSumTestsBase<NumberOfSubArraysWithOddSumBruteForce>;

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumPrefixSumTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumPrefixSumTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfSubArraysWithOddSum;
+
+namespace LeetCode.Tests.Algorithms.NumberOfSubArraysWithOddSum;
+
+[TestClass]
+public class NumberOfSubArraysWithOddSumPrefixSumTests :
+    NumberOfSubArraysWithOddSumTestsBase<NumberOfSubArraysWithOddSumPrefixSum>;

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubArraysWithOddSum/NumberOfSubArraysWithOddSumTestsBase.cs
@@ -1,0 +1,36 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfSubArraysWithOddSum;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.NumberOfSubArraysWithOddSum;
+
+public abstract class NumberOfSubArraysWithOddSumTestsBase<T> where T : INumberOfSubArraysWithOddSum, new()
+{
+    [TestMethod]
+    [DataRow("[1,3,5]", 4)]
+    [DataRow("[2,4,6]", 0)]
+    [DataRow("[1,2,3,4,5,6,7]", 16)]
+    public void NumOfSubarrays_WithGivenArray_ReturnsCountOfOddSumSubarrays(string arrJsonArray, int expectedResult)
+    {
+        // Arrange
+        var arr = JsonHelper<int>.DeserializeToArray(arrJsonArray);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.NumOfSubarrays(arr);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Number of Sub-arrays With Odd Sum' algorithm problem using brute force and a prefix sum approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c03e6815-b7d7-4463-a72a-6b0c2c8301d8)
