### PR TITLE
Maximum Unique Subarray Sum After Deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [3452. Sum of Good Numbers](https://leetcode.com/problems/sum-of-good-numbers/description/)
 - [3461. Check If Digits Are Equal in String After Operations I](https://leetcode.com/problems/check-if-digits-are-equal-in-string-after-operations-i/description/)
 - [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/description/)
+- [3487. Maximum Unique Subarray Sum After Deletion](https://leetcode.com/problems/maximum-unique-subarray-sum-after-deletion/description/)
 
   </p>
 </details>

--- a/source/LeetCode/Algorithms/MaximumUniqueSubarraySumAfterDeletion/IMaximumUniqueSubarraySumAfterDeletion.cs
+++ b/source/LeetCode/Algorithms/MaximumUniqueSubarraySumAfterDeletion/IMaximumUniqueSubarraySumAfterDeletion.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MaximumUniqueSubarraySumAfterDeletion;
+
+/// <summary>
+///     https://leetcode.com/problems/maximum-unique-subarray-sum-after-deletion/description/
+/// </summary>
+public interface IMaximumUniqueSubarraySumAfterDeletion
+{
+    int MaxSum(int[] nums);
+}

--- a/source/LeetCode/Algorithms/MaximumUniqueSubarraySumAfterDeletion/MaximumUniqueSubarraySumAfterDeletionHashSet.cs
+++ b/source/LeetCode/Algorithms/MaximumUniqueSubarraySumAfterDeletion/MaximumUniqueSubarraySumAfterDeletionHashSet.cs
@@ -1,0 +1,42 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MaximumUniqueSubarraySumAfterDeletion;
+
+/// <inheritdoc />
+public class MaximumUniqueSubarraySumAfterDeletionHashSet : IMaximumUniqueSubarraySumAfterDeletion
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <returns></returns>
+    public int MaxSum(int[] nums)
+    {
+        var maxSum = 0;
+        var maxElement = int.MinValue;
+
+        var numsHashSet = new HashSet<int>();
+
+        foreach (var num in nums)
+        {
+            maxElement = Math.Max(maxElement, num);
+
+            if (num > 0 && numsHashSet.Add(num))
+            {
+                maxSum += num;
+            }
+        }
+
+        return maxSum == 0 ? maxElement : maxSum;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/MaximumUniqueSubarraySumAfterDeletion/MaximumUniqueSubarraySumAfterDeletionHashSetTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaximumUniqueSubarraySumAfterDeletion/MaximumUniqueSubarraySumAfterDeletionHashSetTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MaximumUniqueSubarraySumAfterDeletion;
+
+namespace LeetCode.Tests.Algorithms.MaximumUniqueSubarraySumAfterDeletion;
+
+[TestClass]
+public class MaximumUniqueSubarraySumAfterDeletionHashSetTests :
+    MaximumUniqueSubarraySumAfterDeletionTestsBase<MaximumUniqueSubarraySumAfterDeletionHashSet>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MaximumUniqueSubarraySumAfterDeletion/MaximumUniqueSubarraySumAfterDeletionTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaximumUniqueSubarraySumAfterDeletion/MaximumUniqueSubarraySumAfterDeletionTestsBase.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MaximumUniqueSubarraySumAfterDeletion;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.MaximumUniqueSubarraySumAfterDeletion;
+
+public abstract class MaximumUniqueSubarraySumAfterDeletionTestsBase<T>
+    where T : IMaximumUniqueSubarraySumAfterDeletion, new()
+{
+    [TestMethod]
+    [DataRow("[1,2,3,4,5]", 15)]
+    [DataRow("[1,1,0,1,1]", 1)]
+    [DataRow("[1,2,-1,-2,1,0,-1]", 3)]
+    public void MaxSum_WithIntegerArray_ReturnsMaximumSubarraySum(string numsJsonArray, int expectedResult)
+    {
+        // Arrange
+        var nums = JsonHelper<int>.DeserializeToArray(numsJsonArray);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.MaxSum(nums);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Maximum Unique Subarray Sum After Deletion' algorithm problem using a hash set approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/45e97d81-6259-4b14-b5ce-eb02dbaab92a)
