### PR TITLE
Minimum Operations to Make Array Values Equal to K

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [3289. The Two Sneaky Numbers of Digitville](https://leetcode.com/problems/the-two-sneaky-numbers-of-digitville/description/)
 - [3306. Count of Substrings Containing Every Vowel and K Consonants II](https://leetcode.com/problems/count-of-substrings-containing-every-vowel-and-k-consonants-ii/description/)
 - [3340. Check Balanced String](https://leetcode.com/problems/check-balanced-string/description/)
+- [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/description/)
 - [3379. Transformed Array](https://leetcode.com/problems/transformed-array/description/)
 - [3386. Button with Longest Push Time](https://leetcode.com/problems/button-with-longest-push-time/description/)
 - [3394. Check if Grid can be Cut into Sections](https://leetcode.com/problems/check-if-grid-can-be-cut-into-sections/description/)

--- a/source/LeetCode/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/IMinimumOperationsToMakeArrayValuesEqualToK.cs
+++ b/source/LeetCode/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/IMinimumOperationsToMakeArrayValuesEqualToK.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+/// <summary>
+///     https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/description/
+/// </summary>
+public interface IMinimumOperationsToMakeArrayValuesEqualToK
+{
+    int MinOperations(int[] nums, int k);
+}

--- a/source/LeetCode/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKHashSet.cs
+++ b/source/LeetCode/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKHashSet.cs
@@ -1,0 +1,43 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+/// <inheritdoc />
+public class MinimumOperationsToMakeArrayValuesEqualToKHashSet : IMinimumOperationsToMakeArrayValuesEqualToK
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(n)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <param name="k"></param>
+    /// <returns></returns>
+    public int MinOperations(int[] nums, int k)
+    {
+        var numsHashSet = new HashSet<int>();
+
+        foreach (var num in nums)
+        {
+            if (num < k)
+            {
+                return -1;
+            }
+
+            if (num > k)
+            {
+                numsHashSet.Add(num);
+            }
+        }
+
+        return numsHashSet.Count;
+    }
+}

--- a/source/LeetCode/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKSeenArray.cs
+++ b/source/LeetCode/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKSeenArray.cs
@@ -1,0 +1,49 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+/// <inheritdoc />
+public class MinimumOperationsToMakeArrayValuesEqualToKSeenArray : IMinimumOperationsToMakeArrayValuesEqualToK
+{
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <param name="k"></param>
+    /// <returns></returns>
+    public int MinOperations(int[] nums, int k)
+    {
+        var minOperations = 0;
+
+        var seenNums = new bool[100];
+
+        foreach (var num in nums)
+        {
+            if (num < k)
+            {
+                return -1;
+            }
+
+            if (num <= k || seenNums[num - 1])
+            {
+                continue;
+            }
+
+            seenNums[num - 1] = true;
+
+            minOperations++;
+        }
+
+        return minOperations;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKHashSetTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKHashSetTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+namespace LeetCode.Tests.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+[TestClass]
+public class MinimumOperationsToMakeArrayValuesEqualToKHashSetTests :
+    MinimumOperationsToMakeArrayValuesEqualToKTestsBase<MinimumOperationsToMakeArrayValuesEqualToKHashSet>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKSeenArrayTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKSeenArrayTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+namespace LeetCode.Tests.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+[TestClass]
+public class MinimumOperationsToMakeArrayValuesEqualToKSeenArrayTests :
+    MinimumOperationsToMakeArrayValuesEqualToKTestsBase<MinimumOperationsToMakeArrayValuesEqualToKSeenArray>;

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumOperationsToMakeArrayValuesEqualToK/MinimumOperationsToMakeArrayValuesEqualToKTestsBase.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.MinimumOperationsToMakeArrayValuesEqualToK;
+
+public abstract class MinimumOperationsToMakeArrayValuesEqualToKTestsBase<T>
+    where T : IMinimumOperationsToMakeArrayValuesEqualToK, new()
+{
+    [TestMethod]
+    [DataRow("[5,2,5,4,5]", 2, 2)]
+    [DataRow("[2,1,2]", 2, -1)]
+    [DataRow("[9,7,5,3]", 1, 4)]
+    public void MinOperations_WithArrayAndTargetK_ReturnsMinimumStepsOrMinusOne(string numsJsonArray, int k,
+        int expectedResult)
+    {
+        // Arrange
+        var nums = JsonHelper<int>.DeserializeToArray(numsJsonArray);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.MinOperations(nums, k);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Minimum Operations to Make Array Values Equal to K' algorithm problem using a hash set and a seen array approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/c16f8e2a-dc2d-4258-8b9f-d8537b8fd561)
