### PR TITLE
Smallest Index With Digit Sum Equal to Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [3512. Minimum Operations to Make Array Sum Divisible by K](https://leetcode.com/problems/minimum-operations-to-make-array-sum-divisible-by-k/description/)
 - [3516. Find Closest Person](https://leetcode.com/problems/find-closest-person/description/)
 - [3536. Maximum Product of Two Digits](https://leetcode.com/problems/maximum-product-of-two-digits/description/)
+- [3550. Smallest Index With Digit Sum Equal to Index](https://leetcode.com/problems/smallest-index-with-digit-sum-equal-to-index/description/)
 
   </p>
 </details>

--- a/source/LeetCode/Algorithms/SmallestIndexWithDigitSumEqualToIndex/ISmallestIndexWithDigitSumEqualToIndex.cs
+++ b/source/LeetCode/Algorithms/SmallestIndexWithDigitSumEqualToIndex/ISmallestIndexWithDigitSumEqualToIndex.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.SmallestIndexWithDigitSumEqualToIndex;
+
+/// <summary>
+///     https://leetcode.com/problems/smallest-index-with-digit-sum-equal-to-index/description/
+/// </summary>
+public interface ISmallestIndexWithDigitSumEqualToIndex
+{
+    int SmallestIndex(int[] nums);
+}

--- a/source/LeetCode/Algorithms/SmallestIndexWithDigitSumEqualToIndex/SmallestIndexWithDigitSumEqualToIndexBruteForce.cs
+++ b/source/LeetCode/Algorithms/SmallestIndexWithDigitSumEqualToIndex/SmallestIndexWithDigitSumEqualToIndexBruteForce.cs
@@ -1,0 +1,46 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.SmallestIndexWithDigitSumEqualToIndex;
+
+/// <inheritdoc />
+public class SmallestIndexWithDigitSumEqualToIndexBruteForce : ISmallestIndexWithDigitSumEqualToIndex
+{
+    /// <summary>
+    ///     Time complexity - O(n * d)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="nums"></param>
+    /// <returns></returns>
+    public int SmallestIndex(int[] nums)
+    {
+        for (var i = 0; i < nums.Length; i++)
+        {
+            var digitSum = 0;
+
+            var num = nums[i];
+
+            while (num > 0)
+            {
+                digitSum += num % 10;
+
+                num /= 10;
+            }
+
+            if (i == digitSum)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/SmallestIndexWithDigitSumEqualToIndex/SmallestIndexWithDigitSumEqualToIndexBruteForceTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SmallestIndexWithDigitSumEqualToIndex/SmallestIndexWithDigitSumEqualToIndexBruteForceTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.SmallestIndexWithDigitSumEqualToIndex;
+
+namespace LeetCode.Tests.Algorithms.SmallestIndexWithDigitSumEqualToIndex;
+
+[TestClass]
+public class SmallestIndexWithDigitSumEqualToIndexBruteForceTests :
+    SmallestIndexWithDigitSumEqualToIndexTestsBase<SmallestIndexWithDigitSumEqualToIndexBruteForce>;

--- a/source/Tests/LeetCode.Tests/Algorithms/SmallestIndexWithDigitSumEqualToIndex/SmallestIndexWithDigitSumEqualToIndexTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SmallestIndexWithDigitSumEqualToIndex/SmallestIndexWithDigitSumEqualToIndexTestsBase.cs
@@ -1,0 +1,37 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.SmallestIndexWithDigitSumEqualToIndex;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.SmallestIndexWithDigitSumEqualToIndex;
+
+public abstract class SmallestIndexWithDigitSumEqualToIndexTestsBase<T>
+    where T : ISmallestIndexWithDigitSumEqualToIndex, new()
+{
+    [TestMethod]
+    [DataRow("[1,3,2]", 2)]
+    [DataRow("[1,10,11]", 1)]
+    [DataRow("[1,2,3]", -1)]
+    public void SmallestIndex_WithGivenArray_ReturnsCorrectIndexOrMinusOne(string numsJson, int expectedResult)
+    {
+        // Arrange
+        var nums = JsonHelper<int[]>.Parse(numsJson);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.SmallestIndex(nums);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Smallest Index With Digit Sum Equal to Index' algorithm problem using a brute-force approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/ad9e5d07-ea30-40ef-8ead-7982c0799942)
