### PR TITLE
Height of Binary Tree After Subtree Removal Queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [2441. Largest Positive Integer That Exists With Its Negative](https://leetcode.com/problems/largest-positive-integer-that-exists-with-its-negative/description/)
 - [2444. Count Subarrays With Fixed Bounds](https://leetcode.com/problems/count-subarrays-with-fixed-bounds/description/)
 - [2446. Determine if Two Events Have Conflict](https://leetcode.com/problems/determine-if-two-events-have-conflict/description/)
+- [2458. Height of Binary Tree After Subtree Removal Queries](https://leetcode.com/problems/height-of-binary-tree-after-subtree-removal-queries/description/)
 - [2460. Apply Operations to an Array](https://leetcode.com/problems/apply-operations-to-an-array/description/)
 - [2461. Maximum Sum of Distinct Subarrays With Length K](https://leetcode.com/problems/maximum-sum-of-distinct-subarrays-with-length-k/description/)
 - [2469. Convert the Temperature](https://leetcode.com/problems/convert-the-temperature/description/)

--- a/source/LeetCode.Core/Models/ListNode.cs
+++ b/source/LeetCode.Core/Models/ListNode.cs
@@ -11,6 +11,8 @@
 
 // ReSharper disable InconsistentNaming
 
+using LeetCode.Core.Exceptions;
+
 namespace LeetCode.Core.Models;
 
 /// <summary>
@@ -26,6 +28,11 @@ public class ListNode
     {
         this.next = next;
         this.val = val;
+    }
+
+    public static ListNode ToListNodeOrThrow(int[] array)
+    {
+        return ToListNode(array) ?? throw new ListNodeBuildException();
     }
 
     public static ListNode? ToListNode(int[] array)

--- a/source/LeetCode.Core/Models/TreeNode.cs
+++ b/source/LeetCode.Core/Models/TreeNode.cs
@@ -11,6 +11,8 @@
 
 // ReSharper disable InconsistentNaming
 
+using LeetCode.Core.Exceptions;
+
 namespace LeetCode.Core.Models;
 
 /// <summary>
@@ -29,6 +31,11 @@ public class TreeNode
         this.left = left;
         this.right = right;
         this.val = val ?? 0;
+    }
+
+    public static TreeNode ToTreeNodeOrThrow(IEnumerable<int?> values)
+    {
+        return ToTreeNode(values) ?? throw new TreeNodeBuildException();
     }
 
     public static TreeNode? ToTreeNode(IEnumerable<int?> values)

--- a/source/LeetCode/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearch.cs
+++ b/source/LeetCode/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearch.cs
@@ -1,0 +1,193 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Core.Models;
+
+namespace LeetCode.Algorithms.HeightOfBinaryTreeAfterSubtreeRemovalQueries;
+
+/// <inheritdoc />
+public class HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearch :
+    IHeightOfBinaryTreeAfterSubtreeRemovalQueries
+{
+    /// <summary>
+    ///     Time complexity - O(n), where n is the number of nodes and m is the number of queries
+    ///     Space complexity - O(n), where n is the number of nodes
+    /// </summary>
+    /// <param name="root"></param>
+    /// <param name="queries"></param>
+    /// <returns></returns>
+    public int[] TreeQueries(TreeNode root, int[] queries)
+    {
+        var nodesCount = GetNodesCount(root);
+
+        Span<int> heights = stackalloc int[nodesCount + 1];
+
+        LeftToRight(root, heights);
+
+        RightToLeft(root, heights);
+
+        return GetAnswer(queries, heights);
+    }
+
+    /// <summary>
+    ///     Time complexity - O(n), where n is the number of nodes
+    ///     Space complexity - O(n), where n is the number of nodes
+    /// </summary>
+    /// <param name="root"></param>
+    /// <param name="heights"></param>
+    private static void LeftToRight(TreeNode root, Span<int> heights)
+    {
+        var maxHeight = 0;
+
+        var nodesStack = new Stack<(TreeNode Node, int CurrentHeight)>();
+
+        nodesStack.Push((root, -1));
+
+        while (nodesStack.Count > 0)
+        {
+            var (node, currentHeight) = nodesStack.Pop();
+
+            var nodeValue = node.val;
+
+            heights[nodeValue] = Math.Max(Math.Max(maxHeight, currentHeight), heights[nodeValue]);
+
+            var nextHeight = currentHeight + 1;
+
+            maxHeight = Math.Max(maxHeight, nextHeight);
+
+            var leftNode = node.left;
+
+            if (leftNode != null)
+            {
+                nodesStack.Push((leftNode, nextHeight));
+            }
+
+            var rightNode = node.right;
+
+            if (rightNode != null)
+            {
+                nodesStack.Push((rightNode, nextHeight));
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Time complexity - O(n), where n is the number of nodes
+    ///     Space complexity - O(n), where n is the number of nodes
+    /// </summary>
+    /// <param name="root"></param>
+    /// <param name="heights"></param>
+    private static void RightToLeft(TreeNode root, Span<int> heights)
+    {
+        var maxHeight = 0;
+
+        var nodesStack = new Stack<(TreeNode Node, int CurrentHeight)>();
+
+        nodesStack.Push((root, -1));
+
+        while (nodesStack.Count > 0)
+        {
+            var (node, currentHeight) = nodesStack.Pop();
+
+            var nodeValue = node.val;
+
+            heights[nodeValue] = Math.Max(Math.Max(maxHeight, currentHeight), heights[nodeValue]);
+
+            var nextHeight = currentHeight + 1;
+
+            maxHeight = Math.Max(maxHeight, nextHeight);
+
+            var rightNode = node.right;
+
+            if (rightNode != null)
+            {
+                nodesStack.Push((rightNode, nextHeight));
+            }
+
+            var leftNode = node.left;
+
+            if (leftNode != null)
+            {
+                nodesStack.Push((leftNode, nextHeight));
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Time complexity - O(n), where n is the number of nodes
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="root"></param>
+    /// <returns></returns>
+    private static int GetNodesCount(TreeNode? root)
+    {
+        var nodesCount = 0;
+
+        var current = root;
+
+        while (current != null)
+        {
+            if (current.left == null)
+            {
+                nodesCount++;
+
+                current = current.right;
+            }
+            else
+            {
+                var previous = current.left;
+
+                while (previous.right != null && previous.right != current)
+                {
+                    previous = previous.right;
+                }
+
+                if (previous.right == null)
+                {
+                    previous.right = current;
+
+                    current = current.left;
+                }
+                else
+                {
+                    previous.right = null;
+
+                    nodesCount++;
+
+                    current = current.right;
+                }
+            }
+        }
+
+        return nodesCount;
+    }
+
+    /// <summary>
+    ///     Time complexity - O(m), where m is the number of queries
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="queries"></param>
+    /// <param name="heights"></param>
+    /// <returns></returns>
+    private static int[] GetAnswer(int[] queries, ReadOnlySpan<int> heights)
+    {
+        var queriesLength = queries.Length;
+
+        for (var i = 0; i < queriesLength; i++)
+        {
+            var query = queries[i];
+
+            queries[i] = heights[query];
+        }
+
+        return queries;
+    }
+}

--- a/source/LeetCode/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/IHeightOfBinaryTreeAfterSubtreeRemovalQueries.cs
+++ b/source/LeetCode/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/IHeightOfBinaryTreeAfterSubtreeRemovalQueries.cs
@@ -1,0 +1,22 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Core.Models;
+
+namespace LeetCode.Algorithms.HeightOfBinaryTreeAfterSubtreeRemovalQueries;
+
+/// <summary>
+///     https://leetcode.com/problems/height-of-binary-tree-after-subtree-removal-queries/description/
+/// </summary>
+public interface IHeightOfBinaryTreeAfterSubtreeRemovalQueries
+{
+    int[] TreeQueries(TreeNode root, int[] queries);
+}

--- a/source/LeetCode/Algorithms/MaximumNumberOfWordsYouCanType/MaximumNumberOfWordsYouCanTypeLookup.cs
+++ b/source/LeetCode/Algorithms/MaximumNumberOfWordsYouCanType/MaximumNumberOfWordsYouCanTypeLookup.cs
@@ -27,18 +27,22 @@ public class MaximumNumberOfWordsYouCanTypeLookup : IMaximumNumberOfWordsYouCanT
     {
         Span<bool> brokenLettersLookup = stackalloc bool[AlphabetLength];
 
-        for (var i = 0; i < brokenLetters.Length; i++)
+        var brokenLettersLength = brokenLetters.Length;
+
+        for (var i = 0; i < brokenLettersLength; i++)
         {
             var brokenLetterIndex = brokenLetters[i] - 'a';
 
             brokenLettersLookup[brokenLetterIndex] = true;
         }
 
-        var count = 0;
+        var goodWordsCount = 0;
 
         var isBroken = false;
 
-        for (var i = 0; i < text.Length; i++)
+        var textLength = text.Length;
+
+        for (var i = 0; i < textLength; i++)
         {
             var c = text[i];
 
@@ -50,7 +54,7 @@ public class MaximumNumberOfWordsYouCanTypeLookup : IMaximumNumberOfWordsYouCanT
                 }
                 else
                 {
-                    count++;
+                    goodWordsCount++;
                 }
             }
             else
@@ -68,9 +72,9 @@ public class MaximumNumberOfWordsYouCanTypeLookup : IMaximumNumberOfWordsYouCanT
 
         if (!isBroken)
         {
-            count++;
+            goodWordsCount++;
         }
 
-        return count;
+        return goodWordsCount;
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/AddTwoNumbers2/AddTwoNumbers2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/AddTwoNumbers2/AddTwoNumbers2TestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.AddTwoNumbers2;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -28,10 +27,10 @@ public abstract class AddTwoNumbers2TestsBase<T> where T : IAddTwoNumbers2, new(
     {
         // Arrange
         var l1Array = JsonHelper<int[]>.Parse(l1Json);
-        var l1 = ListNode.ToListNode(l1Array) ?? throw new ListNodeBuildException();
+        var l1 = ListNode.ToListNodeOrThrow(l1Array);
 
         var l2Array = JsonHelper<int[]>.Parse(l2Json);
-        var l2 = ListNode.ToListNode(l2Array) ?? throw new ListNodeBuildException();
+        var l2 = ListNode.ToListNodeOrThrow(l2Array);
 
         var expectedResultArray = JsonHelper<int[]>.Parse(expectedResultJson);
         var expectedResult = ListNode.ToListNode(expectedResultArray);

--- a/source/Tests/LeetCode.Tests/Algorithms/ConvertBinaryNumberInLinkedListToInteger/ConvertBinaryNumberInLinkedListToIntegerTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConvertBinaryNumberInLinkedListToInteger/ConvertBinaryNumberInLinkedListToIntegerTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.ConvertBinaryNumberInLinkedListToInteger;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
@@ -26,8 +25,7 @@ public abstract class ConvertBinaryNumberInLinkedListToIntegerTestsBase<T>
     {
         // Arrange
         var headArray = JsonHelper<int[]>.Parse(headJson);
-
-        var head = ListNode.ToListNode(headArray) ?? throw new ListNodeBuildException();
+        var head = ListNode.ToListNodeOrThrow(headArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/CousinsInBinaryTree2/CousinsInBinaryTree2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CousinsInBinaryTree2/CousinsInBinaryTree2TestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.CousinsInBinaryTree2;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -29,7 +28,7 @@ public abstract class CousinsInBinaryTree2TestsBase<T> where T : ICousinsInBinar
         var expectedResultArray = JsonHelper<int?[]>.Parse(expectedResultJson);
         var expectedResult = TreeNode.ToTreeNode(expectedResultArray);
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree/FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.FindCorrespondingNodeOfBinaryTreeInCloneOfThatTree;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -29,8 +28,8 @@ public abstract class FindCorrespondingNodeOfBinaryTreeInCloneOfThatTreeTestsBas
     {
         // Arrange
         var treeArray = JsonHelper<int?[]>.Parse(treeJson);
-        var original = TreeNode.ToTreeNode(treeArray) ?? throw new TreeNodeBuildException();
-        var cloned = TreeNode.ToTreeNode(treeArray) ?? throw new TreeNodeBuildException();
+        var original = TreeNode.ToTreeNodeOrThrow(treeArray);
+        var cloned = TreeNode.ToTreeNodeOrThrow(treeArray);
 
         TreeNode? target = null;
 

--- a/source/Tests/LeetCode.Tests/Algorithms/FindElementsInContaminatedBinaryTree/FindElementsInContaminatedBinaryTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindElementsInContaminatedBinaryTree/FindElementsInContaminatedBinaryTreeTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.FindElementsInContaminatedBinaryTree;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Exceptions;
@@ -31,7 +30,7 @@ public abstract class FindElementsInContaminatedBinaryTreeTestsBase
     {
         // Arrange
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
         var methods = JsonHelper<string[]>.Parse(methodsJson);
         var arguments = JsonHelper<object[][]>.Parse(argumentsJson);
         var expectedResult = JsonHelper<object[]>.Parse(expectedResultJson);

--- a/source/Tests/LeetCode.Tests/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearchTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearchTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.HeightOfBinaryTreeAfterSubtreeRemovalQueries;
+
+namespace LeetCode.Tests.Algorithms.HeightOfBinaryTreeAfterSubtreeRemovalQueries;
+
+[TestClass]
+public class HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearchTests :
+    HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase<HeightOfBinaryTreeAfterSubtreeRemovalQueriesDepthFirstSearch>;

--- a/source/Tests/LeetCode.Tests/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase.cs
@@ -9,32 +9,34 @@
 // known as Yevhenii Yeriemeieiv).
 // --------------------------------------------------------------------------------
 
-using LeetCode.Algorithms.MinimumNumberOfOperationsToSortBinaryTreeByLevel;
+using LeetCode.Algorithms.HeightOfBinaryTreeAfterSubtreeRemovalQueries;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
-namespace LeetCode.Tests.Algorithms.MinimumNumberOfOperationsToSortBinaryTreeByLevel;
+namespace LeetCode.Tests.Algorithms.HeightOfBinaryTreeAfterSubtreeRemovalQueries;
 
-public abstract class MinimumNumberOfOperationsToSortBinaryTreeByLevelTestsBase<T>
-    where T : IMinimumNumberOfOperationsToSortBinaryTreeByLevel, new()
+public abstract class HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase<T>
+    where T : IHeightOfBinaryTreeAfterSubtreeRemovalQueries, new()
 {
     [TestMethod]
-    [DataRow("[1,2,3,4,5,6]", 0)]
-    [DataRow("[1,3,2,7,6,5,4]", 3)]
-    [DataRow("[1,4,3,7,6,8,5,null,null,null,null,9,null,10]", 3)]
-    public void MinimumOperations_WithBinaryTreeInput_ReturnsMinOperationsToSortLevelOrders(string rootJson,
-        int expectedResult)
+    [DataRow("[1,3,4,2,null,6,5,null,null,null,null,null,7]", "[4]", "[2]")]
+    [DataRow("[5,8,9,2,1,3,7,4,6]", "[3,2,4,8]", "[3,2,3,2]")]
+    [DataRow("[1,null,5,3,null,2,4]", "[3,5,4,2,4]", "[1,0,3,3,3]")]
+    public void TreeQueries_WithSubtreeRemovedAtGivenNode_ReturnsHeightOfTreeAfterRemoval(string rootJson,
+        string queriesJson, string expectedResultJson)
     {
         // Arrange
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
         var root = TreeNode.ToTreeNodeOrThrow(rootArray);
+        var queries = JsonHelper<int[]>.Parse(queriesJson);
+        var expectedResult = JsonHelper<int[]>.Parse(expectedResultJson);
 
         var solution = new T();
 
         // Act
-        var actualResult = solution.MinimumOperations(root);
+        var actualResult = solution.TreeQueries(root, queries);
 
         // Assert
-        Assert.AreEqual(expectedResult, actualResult);
+        CollectionAssert.AreEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/InsertGreatestCommonDivisorsInLinkedList/InsertGreatestCommonDivisorsInLinkedListTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/InsertGreatestCommonDivisorsInLinkedList/InsertGreatestCommonDivisorsInLinkedListTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.InsertGreatestCommonDivisorsInLinkedList;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -28,7 +27,7 @@ public abstract class InsertGreatestCommonDivisorsInLinkedListTestsBase<T>
     {
         // Arrange
         var headArray = JsonHelper<int[]>.Parse(headJson);
-        var head = ListNode.ToListNode(headArray) ?? throw new ListNodeBuildException();
+        var head = ListNode.ToListNodeOrThrow(headArray);
         var expectedResultArray = JsonHelper<int[]>.Parse(expectedResultJson);
         var expectedResult = ListNode.ToListNode(expectedResultArray);
 

--- a/source/Tests/LeetCode.Tests/Algorithms/KthLargestSumInBinaryTree/KthLargestSumInBinaryTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/KthLargestSumInBinaryTree/KthLargestSumInBinaryTreeTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.KthLargestSumInBinaryTree;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
@@ -26,7 +25,7 @@ public abstract class KthLargestSumInBinaryTreeTestsBase<T> where T : IKthLarges
     {
         // Arrange
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/LinkedListInBinaryTree/LinkedListInBinaryTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LinkedListInBinaryTree/LinkedListInBinaryTreeTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.LinkedListInBinaryTree;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
@@ -30,9 +29,9 @@ public abstract class LinkedListInBinaryTreeTestsBase<T> where T : ILinkedListIn
     {
         // Arrange
         var headArray = JsonHelper<int[]>.Parse(headJson);
-        var head = ListNode.ToListNode(headArray) ?? throw new ListNodeBuildException();
+        var head = ListNode.ToListNodeOrThrow(headArray);
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/LowestCommonAncestorOfDeepestLeaves/LowestCommonAncestorOfDeepestLeavesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LowestCommonAncestorOfDeepestLeaves/LowestCommonAncestorOfDeepestLeavesTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.LowestCommonAncestorOfDeepestLeaves;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -31,9 +30,9 @@ public abstract class LowestCommonAncestorOfDeepestLeavesTestsBase<T>
         var solution = new T();
 
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
         var expectedResultArray = JsonHelper<int?[]>.Parse(expectedResultJson);
-        var expectedResult = TreeNode.ToTreeNode(expectedResultArray) ?? throw new TreeNodeBuildException();
+        var expectedResult = TreeNode.ToTreeNodeOrThrow(expectedResultArray);
 
         // Act
         var actualResult = solution.LcaDeepestLeaves(root);

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumAbsoluteDifferenceInBST/MinimumAbsoluteDifferenceInBSTTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumAbsoluteDifferenceInBST/MinimumAbsoluteDifferenceInBSTTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.MinimumAbsoluteDifferenceInBST;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
@@ -26,7 +25,7 @@ public abstract class MinimumAbsoluteDifferenceInBSTTestsBase<T> where T : IMini
     {
         // Arrange
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumDistanceBetweenBSTNodes/MinimumDistanceBetweenBSTNodesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumDistanceBetweenBSTNodes/MinimumDistanceBetweenBSTNodesTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.MinimumDistanceBetweenBSTNodes;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
@@ -26,7 +25,7 @@ public abstract class MinimumDistanceBetweenBSTNodesTestsBase<T> where T : IMini
     {
         // Arrange
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/RootEqualsSumOfChildren/RootEqualsSumOfChildrenTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RootEqualsSumOfChildren/RootEqualsSumOfChildrenTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.RootEqualsSumOfChildren;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 
@@ -26,7 +25,7 @@ public abstract class RootEqualsSumOfChildrenTestsBase<T> where T : IRootEqualsS
     {
         // Arrange
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
 
         var solution = new T();
 

--- a/source/Tests/LeetCode.Tests/Algorithms/SmallestSubtreeWithAllTheDeepestNodes/SmallestSubtreeWithAllTheDeepestNodesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SmallestSubtreeWithAllTheDeepestNodes/SmallestSubtreeWithAllTheDeepestNodesTestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.SmallestSubtreeWithAllTheDeepestNodes;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -31,9 +30,9 @@ public abstract class SmallestSubtreeWithAllTheDeepestNodesTestsBase<T>
         var solution = new T();
 
         var rootArray = JsonHelper<int?[]>.Parse(rootJson);
-        var root = TreeNode.ToTreeNode(rootArray) ?? throw new TreeNodeBuildException();
+        var root = TreeNode.ToTreeNodeOrThrow(rootArray);
         var expectedResultArray = JsonHelper<int?[]>.Parse(expectedResultJson);
-        var expectedResult = TreeNode.ToTreeNode(expectedResultArray) ?? throw new TreeNodeBuildException();
+        var expectedResult = TreeNode.ToTreeNodeOrThrow(expectedResultArray);
 
         // Act
         var actualResult = solution.SubtreeWithAllDeepest(root);

--- a/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix4/SpiralMatrix4TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix4/SpiralMatrix4TestsBase.cs
@@ -10,7 +10,6 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.SpiralMatrix4;
-using LeetCode.Core.Exceptions;
 using LeetCode.Core.Helpers;
 using LeetCode.Core.Models;
 using LeetCode.Tests.Base.Extensions;
@@ -28,7 +27,7 @@ public abstract class SpiralMatrix4TestsBase<T> where T : ISpiralMatrix4, new()
     {
         // Arrange
         var headArray = JsonHelper<int[]>.Parse(headJson);
-        var head = ListNode.ToListNode(headArray) ?? throw new ListNodeBuildException();
+        var head = ListNode.ToListNodeOrThrow(headArray);
         var expectedResult = JsonHelper<int[][]>.Parse(expectedResultJson);
 
         var solution = new T();


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Height of Binary Tree After Subtree Removal Queries' algorithm problem using a depth first search approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
<img width="687" height="442" alt="image" src="https://github.com/user-attachments/assets/c64593f3-0638-44c3-b663-33f9d426d365" />
