### PR TITLE
Number of Substrings With Only 1s

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [1508. Range Sum of Sorted Subarray Sums](https://leetcode.com/problems/range-sum-of-sorted-subarray-sums/description/)
 - [1509. Minimum Difference Between Largest and Smallest Value in Three Moves](https://leetcode.com/problems/minimum-difference-between-largest-and-smallest-value-in-three-moves/description/)
 - [1512. Number of Good Pairs](https://leetcode.com/problems/number-of-good-pairs/description/)
+- [1513. Number of Substrings With Only 1s](https://leetcode.com/problems/number-of-substrings-with-only-1s/description/)
 - [1514. Path with Maximum Probability](https://leetcode.com/problems/path-with-maximum-probability/description/)
 - [1518. Water Bottles](https://leetcode.com/problems/water-bottles/description/)
 - [1523. Count Odd Numbers in an Interval Range](https://leetcode.com/problems/count-odd-numbers-in-an-interval-range/description/)

--- a/source/LeetCode/Algorithms/NumberOfSubstringsWithOnlyOnes/INumberOfSubstringsWithOnlyOnes.cs
+++ b/source/LeetCode/Algorithms/NumberOfSubstringsWithOnlyOnes/INumberOfSubstringsWithOnlyOnes.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfSubstringsWithOnlyOnes;
+
+/// <summary>
+///     https://leetcode.com/problems/number-of-substrings-with-only-1s/description/
+/// </summary>
+public interface INumberOfSubstringsWithOnlyOnes
+{
+    int NumSub(string s);
+}

--- a/source/LeetCode/Algorithms/NumberOfSubstringsWithOnlyOnes/NumberOfSubstringsWithOnlyOnesCounting.cs
+++ b/source/LeetCode/Algorithms/NumberOfSubstringsWithOnlyOnes/NumberOfSubstringsWithOnlyOnesCounting.cs
@@ -1,0 +1,49 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfSubstringsWithOnlyOnes;
+
+/// <inheritdoc />
+public class NumberOfSubstringsWithOnlyOnesCounting : INumberOfSubstringsWithOnlyOnes
+{
+    private const int Modulo = 1_000_000_007;
+
+    /// <summary>
+    ///     Time complexity - O(n)
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="s"></param>
+    /// <returns></returns>
+    public int NumSub(string s)
+    {
+        var result = 0;
+
+        var count = 0;
+
+        for (var i = 0; i < s.Length; i++)
+        {
+            var c = s[i];
+
+            if (c == '1')
+            {
+                count++;
+
+                result = (result + count) % Modulo;
+            }
+            else
+            {
+                count = 0;
+            }
+        }
+
+        return result;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubstringsWithOnlyOnes/NumberOfSubstringsWithOnlyOnesCountingTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubstringsWithOnlyOnes/NumberOfSubstringsWithOnlyOnesCountingTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfSubstringsWithOnlyOnes;
+
+namespace LeetCode.Tests.Algorithms.NumberOfSubstringsWithOnlyOnes;
+
+[TestClass]
+public class NumberOfSubstringsWithOnlyOnesCountingTests :
+    NumberOfSubstringsWithOnlyOnesTestsBase<NumberOfSubstringsWithOnlyOnesCounting>;

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubstringsWithOnlyOnes/NumberOfSubstringsWithOnlyOnesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfSubstringsWithOnlyOnes/NumberOfSubstringsWithOnlyOnesTestsBase.cs
@@ -1,0 +1,34 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2025 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfSubstringsWithOnlyOnes;
+
+namespace LeetCode.Tests.Algorithms.NumberOfSubstringsWithOnlyOnes;
+
+public abstract class NumberOfSubstringsWithOnlyOnesTestsBase<T>
+    where T : INumberOfSubstringsWithOnlyOnes, new()
+{
+    [TestMethod]
+    [DataRow("0110111", 9)]
+    [DataRow("101", 2)]
+    [DataRow("111111", 21)]
+    public void NumSub_WithBinaryString_ReturnsCountOfAllOneSubstrings(string s, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.NumSub(s);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Number of Substrings With Only 1s' algorithm problem using a counting approach.
## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
<img width="685" height="449" alt="image" src="https://github.com/user-attachments/assets/34e6397b-863c-4c58-b079-3e122e4cf569" />
