### PR TITLE
Count Partitions with Even Sum Difference

### DIFF
--- a/source/LeetCode/Algorithms/CountPartitionsWithEvenSumDifference/CountPartitionsWithEvenSumDifferencePrefixSum.cs
+++ b/source/LeetCode/Algorithms/CountPartitionsWithEvenSumDifference/CountPartitionsWithEvenSumDifferencePrefixSum.cs
@@ -23,7 +23,15 @@ public class CountPartitionsWithEvenSumDifferencePrefixSum : ICountPartitionsWit
     public int CountPartitions(int[] nums)
     {
         var left = nums[0];
-        var right = nums.Sum() - nums[0];
+
+        var sum = 0;
+
+        foreach (var num in nums)
+        {
+            sum += num;
+        }
+
+        var right = sum - nums[0];
 
         var count = 0;
 

--- a/source/LeetCode/Algorithms/CountPartitionsWithEvenSumDifference/CountPartitionsWithEvenSumDifferencePrefixSum.cs
+++ b/source/LeetCode/Algorithms/CountPartitionsWithEvenSumDifference/CountPartitionsWithEvenSumDifferencePrefixSum.cs
@@ -26,8 +26,10 @@ public class CountPartitionsWithEvenSumDifferencePrefixSum : ICountPartitionsWit
 
         var sum = 0;
 
-        foreach (var num in nums)
+        for (var i = 0; i < nums.Length; i++)
         {
+            var num = nums[i];
+
             sum += num;
         }
 


### PR DESCRIPTION
# Pull Request

## Description

I've optimized a solution for the 'Count Partitions with Even Sum Difference' algorithm problem using a loop for sum instead of linq.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
<img width="684" height="449" alt="image" src="https://github.com/user-attachments/assets/12674621-2c2f-40db-ba6e-61d23accbc8c" />
