### PR TITLE
Find Resultant Array After Removing Anagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [2257. Count Unguarded Cells in the Grid](https://leetcode.com/problems/count-unguarded-cells-in-the-grid/description/)
 - [2264. Largest 3-Same-Digit Number in String](https://leetcode.com/problems/largest-3-same-digit-number-in-string/description/)
 - [2270. Number of Ways to Split Array](https://leetcode.com/problems/number-of-ways-to-split-array/description/)
+- [2273. Find Resultant Array After Removing Anagrams](https://leetcode.com/problems/find-resultant-array-after-removing-anagrams/description/)
 - [2275. Largest Combination With Bitwise AND Greater Than Zero](https://leetcode.com/problems/largest-combination-with-bitwise-and-greater-than-zero/description/)
 - [2288. Apply Discount to Prices](https://leetcode.com/problems/apply-discount-to-prices/description/)
 - [2290. Minimum Obstacle Removal to Reach Corner](https://leetcode.com/problems/minimum-obstacle-removal-to-reach-corner/description/)

--- a/source/LeetCode/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsGreedyCounting.cs
+++ b/source/LeetCode/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsGreedyCounting.cs
@@ -1,0 +1,82 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindResultantArrayAfterRemovingAnagrams;
+
+/// <inheritdoc />
+public sealed class FindResultantArrayAfterRemovingAnagramsGreedyCounting : IFindResultantArrayAfterRemovingAnagrams
+{
+    private const byte AlphabetLength = 'z' - 'a' + 1;
+
+    /// <summary>
+    ///     Time complexity - O(n * L), where n is the number of words and L is the average length of a word
+    ///     Space complexity - O(1)
+    /// </summary>
+    /// <param name="words"></param>
+    /// <returns></returns>
+    public IList<string> RemoveAnagrams(string[] words)
+    {
+        var result = new List<string>(words.Length)
+        {
+            words[0]
+        };
+
+        for (var i = 1; i < words.Length; i++)
+        {
+            if (AreAnagrams(words[i], result[^1]))
+            {
+                continue;
+            }
+
+            result.Add(words[i]);
+        }
+
+        return result;
+    }
+
+    private static bool AreAnagrams(string a, string b)
+    {
+        if (a.Length != b.Length)
+        {
+            return false;
+        }
+
+        Span<int> frequencies = stackalloc int[AlphabetLength];
+
+        for (var i = 0; i < a.Length; i++)
+        {
+            var aIndex = GetIndex(a[i]);
+
+            frequencies[aIndex]++;
+
+            var bIndex = GetIndex(b[i]);
+
+            frequencies[bIndex]--;
+        }
+
+        for (var i = 0; i < AlphabetLength; i++)
+        {
+            if (frequencies[i] == 0)
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static int GetIndex(char c)
+    {
+        return c - 'a';
+    }
+}

--- a/source/LeetCode/Algorithms/FindResultantArrayAfterRemovingAnagrams/IFindResultantArrayAfterRemovingAnagrams.cs
+++ b/source/LeetCode/Algorithms/FindResultantArrayAfterRemovingAnagrams/IFindResultantArrayAfterRemovingAnagrams.cs
@@ -1,0 +1,20 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.FindResultantArrayAfterRemovingAnagrams;
+
+/// <summary>
+///     https://leetcode.com/problems/find-resultant-array-after-removing-anagrams/description/
+/// </summary>
+public interface IFindResultantArrayAfterRemovingAnagrams
+{
+    IList<string> RemoveAnagrams(string[] words);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsGreedyCountingTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsGreedyCountingTests.cs
@@ -1,0 +1,18 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindResultantArrayAfterRemovingAnagrams;
+
+namespace LeetCode.Tests.Algorithms.FindResultantArrayAfterRemovingAnagrams;
+
+[TestClass]
+public sealed class FindResultantArrayAfterRemovingAnagramsGreedyCountingTests :
+    FindResultantArrayAfterRemovingAnagramsTestsBase<FindResultantArrayAfterRemovingAnagramsGreedyCounting>;

--- a/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsTestsBase.cs
@@ -1,0 +1,38 @@
+﻿// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.FindResultantArrayAfterRemovingAnagrams;
+using LeetCode.Core.Helpers;
+
+namespace LeetCode.Tests.Algorithms.FindResultantArrayAfterRemovingAnagrams;
+
+public abstract class FindResultantArrayAfterRemovingAnagramsTestsBase<T>
+    where T : IFindResultantArrayAfterRemovingAnagrams, new()
+{
+    [TestMethod]
+    [DataRow("[\"abba\",\"baba\",\"bbaa\",\"cd\",\"cd\"]", "[\"abba\",\"cd\"]")]
+    [DataRow("\"a\",\"b\",\"c\",\"d\",\"e\"]", "[\"a\",\"b\",\"c\",\"d\",\"e\"]")]
+    public void RemoveAnagrams_WithWordsArray_RemovesAllSubsequentAnagramDuplicates(string wordsJson,
+        string expectedResultJson)
+    {
+        // Arrange
+        var words = JsonHelper<string[]>.Parse(wordsJson);
+        var expectedResult = JsonHelper<string[]>.Parse(expectedResultJson);
+
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.RemoveAnagrams(words).ToArray();
+
+        // Assert
+        CollectionAssert.AreEqual(expectedResult, actualResult);
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsTestsBase.cs
@@ -19,7 +19,7 @@ public abstract class FindResultantArrayAfterRemovingAnagramsTestsBase<T>
 {
     [TestMethod]
     [DataRow("[\"abba\",\"baba\",\"bbaa\",\"cd\",\"cd\"]", "[\"abba\",\"cd\"]")]
-    [DataRow("\"a\",\"b\",\"c\",\"d\",\"e\"]", "[\"a\",\"b\",\"c\",\"d\",\"e\"]")]
+    [DataRow("[\"a\",\"b\",\"c\",\"d\",\"e\"]", "[\"a\",\"b\",\"c\",\"d\",\"e\"]")]
     public void RemoveAnagrams_WithWordsArray_RemovesAllSubsequentAnagramDuplicates(string wordsJson,
         string expectedResultJson)
     {


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Find Resultant Array After Removing Anagrams' algorithm problem using a greedy counting approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

## Screenshots (if appropriate):
<img width="679" height="446" alt="image" src="https://github.com/user-attachments/assets/7fcc2e98-4a10-4201-8184-42f31c6cd1a1" />
