### PR TITLE
Number of Strings That Appear as Substrings in Word

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [1957. Delete Characters to Make Fancy String](https://leetcode.com/problems/delete-characters-to-make-fancy-string/description/)
 - [1961. Check If String Is a Prefix of Array](https://leetcode.com/problems/check-if-string-is-a-prefix-of-array/description/)
 - [1963. Minimum Number of Swaps to Make the String Balanced](https://leetcode.com/problems/minimum-number-of-swaps-to-make-the-string-balanced/description/)
+- [1967. Number of Strings That Appear as Substrings in Word](https://leetcode.com/problems/number-of-strings-that-appear-as-substrings-in-word/description/)
 - [1971. Find if Path Exists in Graph](https://leetcode.com/problems/find-if-path-exists-in-graph/description/)
 - [1975. Maximum Matrix Sum](https://leetcode.com/problems/maximum-matrix-sum/description/)
 - [1980. Find Unique Binary String](https://leetcode.com/problems/find-unique-binary-string/description/)

--- a/source/LeetCode/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/INumberOfStringsThatAppearAsSubstringsInWord.cs
+++ b/source/LeetCode/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/INumberOfStringsThatAppearAsSubstringsInWord.cs
@@ -1,0 +1,26 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfStringsThatAppearAsSubstringsInWord;
+
+/// <summary>
+///     https://leetcode.com/problems/number-of-strings-that-appear-as-substrings-in-word/description/
+/// </summary>
+public interface INumberOfStringsThatAppearAsSubstringsInWord
+{
+    /// <summary>
+    ///     Counts how many strings in <paramref name="patterns" /> appear as a substring of <paramref name="word" />.
+    /// </summary>
+    /// <param name="patterns">The array of pattern strings to look for in <paramref name="word" />.</param>
+    /// <param name="word">The string in which the patterns are searched.</param>
+    /// <returns>The number of strings in <paramref name="patterns" /> that exist as a substring of <paramref name="word" />.</returns>
+    int NumOfStrings(string[] patterns, string word);
+}

--- a/source/LeetCode/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/NumberOfStringsThatAppearAsSubstringsInWordIterative.cs
+++ b/source/LeetCode/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/NumberOfStringsThatAppearAsSubstringsInWordIterative.cs
@@ -1,0 +1,40 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.NumberOfStringsThatAppearAsSubstringsInWord;
+
+/// <inheritdoc />
+public sealed class NumberOfStringsThatAppearAsSubstringsInWordIterative : INumberOfStringsThatAppearAsSubstringsInWord
+{
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Time complexity - O(m * n * k), where m is the number of patterns, n is the length of the word, and k is the maximum pattern length.
+    ///     Space complexity - O(1)
+    /// </remarks>
+    public int NumOfStrings(string[] patterns, string word)
+    {
+        var result = 0;
+
+        var n = patterns.Length;
+
+        for (var i = 0; i < n; i++)
+        {
+            var pattern = patterns[i];
+
+            if (word.Contains(pattern))
+            {
+                result++;
+            }
+        }
+
+        return result;
+    }
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/NumberOfStringsThatAppearAsSubstringsInWordIterativeTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/NumberOfStringsThatAppearAsSubstringsInWordIterativeTests.cs
@@ -1,0 +1,17 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfStringsThatAppearAsSubstringsInWord;
+
+namespace LeetCode.Tests.Algorithms.NumberOfStringsThatAppearAsSubstringsInWord;
+
+[TestClass]
+public sealed class NumberOfStringsThatAppearAsSubstringsInWordIterativeTests : NumberOfStringsThatAppearAsSubstringsInWordTestsBase<NumberOfStringsThatAppearAsSubstringsInWordIterative>;

--- a/source/Tests/LeetCode.Tests/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/NumberOfStringsThatAppearAsSubstringsInWordTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NumberOfStringsThatAppearAsSubstringsInWord/NumberOfStringsThatAppearAsSubstringsInWordTestsBase.cs
@@ -1,0 +1,52 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.NumberOfStringsThatAppearAsSubstringsInWord;
+
+namespace LeetCode.Tests.Algorithms.NumberOfStringsThatAppearAsSubstringsInWord;
+
+public abstract class NumberOfStringsThatAppearAsSubstringsInWordTestsBase<T> where T : INumberOfStringsThatAppearAsSubstringsInWord, new()
+{
+    [TestMethod]
+    [DataRow(new[] { "a", "abc", "bc", "d" }, "abc", 3)]
+    [DataRow(new[] { "a", "b", "c" }, "aaaaabbbbb", 2)]
+    [DataRow(new[] { "a", "a", "a" }, "ab", 3)]
+    [DataRow(new[] { "abc", "def" }, "xyz", 0)]
+    [DataRow(new[] { "abc" }, "abc", 1)]
+    [DataRow(new[] { "abcd" }, "abc", 0)]
+    [DataRow(new[] { "" }, "abc", 1)]
+    [DataRow(new[] { "z" }, "z", 1)]
+    [DataRow(new[] { "z" }, "y", 0)]
+    [DataRow(new[] { "leet", "code", "leetcode" }, "leetcode", 3)]
+    [DataRow(new[] { "leet", "code", "leetcodes" }, "leetcode", 2)]
+    [DataRow(new[] { "ab", "ba", "aa", "bb" }, "abab", 2)]
+    [DataRow(new[] { "x", "xx", "xxx" }, "xxxx", 3)]
+    [DataRow(new[] { "x", "xx", "xxxxx" }, "xxxx", 2)]
+    [DataRow(new[] { "hello", "world" }, "helloworld", 2)]
+    [DataRow(new[] { "hello", "word" }, "helloworld", 1)]
+    [DataRow(new[] { "aaa", "aa", "a" }, "aaaa", 3)]
+    [DataRow(new[] { "cat", "dog", "bird" }, "thecatandthedog", 2)]
+    [DataRow(new[] { "the", "and", "fox" }, "thecatandthedog", 2)]
+    [DataRow(new[] { "abc", "bca", "cab" }, "abcabc", 3)]
+    [DataRow(new[] { "qrs", "tuv", "wxy" }, "abcdefg", 0)]
+    [DataRow(new[] { "g", "fg", "efg" }, "abcdefg", 3)]
+    public void NumOfStrings_WithPatternsAndWord_ReturnsMatchingPatternCount(string[] patterns, string word, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.NumOfStrings(patterns, word);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

I've implemented a solution for the 'Number of Strings That Appear as Substrings in Word' problem using an iterative approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if appropriate):
<img width="615" height="388" alt="image" src="https://github.com/user-attachments/assets/f41cdd9c-585f-4dae-8246-cde42a90b07b" />
