### PR TITLE
Count Submatrices with Top-Left Element and Sum Less Than k

### DIFF
--- a/README.md
+++ b/README.md
@@ -767,6 +767,7 @@ Below are the LeetCode problems sorted by category. Click on the category names 
 - [3046. Split the Array](https://leetcode.com/problems/split-the-array/description/)
 - [3066. Minimum Operations to Exceed Threshold Value II](https://leetcode.com/problems/minimum-operations-to-exceed-threshold-value-ii/description/)
 - [3068. Find the Maximum Sum of Node Values](https://leetcode.com/problems/find-the-maximum-sum-of-node-values/description/)
+- [3070. Count Submatrices with Top-Left Element and Sum Less Than k](https://leetcode.com/problems/count-submatrices-with-top-left-element-and-sum-less-than-k/description/)
 - [3074. Apple Redistribution into Boxes](https://leetcode.com/problems/apple-redistribution-into-boxes/description/)
 - [3075. Maximize Happiness of Selected Children](https://leetcode.com/problems/maximize-happiness-of-selected-children/description/)
 - [3085. Minimum Deletions to Make String K-Special](https://leetcode.com/problems/minimum-deletions-to-make-string-k-special/description/)

--- a/source/LeetCode/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSum.cs
+++ b/source/LeetCode/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSum.cs
@@ -1,0 +1,48 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.CountSubmatricesWithTopLeftElementAndSumLessThanK;
+
+/// <inheritdoc />
+public sealed class CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSum : ICountSubmatricesWithTopLeftElementAndSumLessThanK
+{
+    /// <inheritdoc />
+    /// <remarks>
+    ///     Time complexity - O(n * m), where n is the number of rows and m is the number of columns
+    ///     Space complexity - O(1)
+    /// </remarks>
+    public int CountSubmatrices(int[][] grid, int k)
+    {
+        var n = grid.Length;
+        var m = grid[0].Length;
+
+        var result = 0;
+
+        for (var i = 0; i < n; i++)
+        {
+            for (var j = 0; j < m; j++)
+            {
+                var top = i > 0 ? grid[i - 1][j] : 0;
+                var left = j > 0 ? grid[i][j - 1] : 0;
+                var topLeft = i > 0 && j > 0 ? grid[i - 1][j - 1] : 0;
+
+                grid[i][j] += top + left - topLeft;
+
+                if (grid[i][j] <= k)
+                {
+                    result++;
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/source/LeetCode/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/ICountSubmatricesWithTopLeftElementAndSumLessThanK.cs
+++ b/source/LeetCode/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/ICountSubmatricesWithTopLeftElementAndSumLessThanK.cs
@@ -1,0 +1,27 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+namespace LeetCode.Algorithms.CountSubmatricesWithTopLeftElementAndSumLessThanK;
+
+/// <summary>
+///     https://leetcode.com/problems/count-submatrices-with-top-left-element-and-sum-less-than-k/description/
+/// </summary>
+public interface ICountSubmatricesWithTopLeftElementAndSumLessThanK
+{
+    /// <summary>
+    ///     Counts the submatrices of <paramref name="grid" /> that contain the top-left element of the grid and have a sum
+    ///     less than or equal to <paramref name="k" />.
+    /// </summary>
+    /// <param name="grid">The matrix of integers.</param>
+    /// <param name="k">The maximum allowed submatrix sum.</param>
+    /// <returns>The number of submatrices containing the top-left element whose sum is less than or equal to <paramref name="k" />.</returns>
+    int CountSubmatrices(int[][] grid, int k);
+}

--- a/source/Tests/LeetCode.Tests/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSumTests.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSumTests.cs
@@ -1,0 +1,17 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.CountSubmatricesWithTopLeftElementAndSumLessThanK;
+
+namespace LeetCode.Tests.Algorithms.CountSubmatricesWithTopLeftElementAndSumLessThanK;
+
+[TestClass]
+public sealed class CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSumTests : CountSubmatricesWithTopLeftElementAndSumLessThanKTestsBase<CountSubmatricesWithTopLeftElementAndSumLessThanKPrefixSum>;

--- a/source/Tests/LeetCode.Tests/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/CountSubmatricesWithTopLeftElementAndSumLessThanKTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountSubmatricesWithTopLeftElementAndSumLessThanK/CountSubmatricesWithTopLeftElementAndSumLessThanKTestsBase.cs
@@ -1,0 +1,82 @@
+// --------------------------------------------------------------------------------
+// Copyright (C) 2026 Eugene Eremeev (also known as Yevhenii Yeriemeieiv).
+// All Rights Reserved.
+// --------------------------------------------------------------------------------
+// This software is the confidential and proprietary information of Eugene Eremeev
+// (also known as Yevhenii Yeriemeieiv) ("Confidential Information"). You shall not
+// disclose such Confidential Information and shall use it only in accordance with
+// the terms of the license agreement you entered into with Eugene Eremeev (also
+// known as Yevhenii Yeriemeieiv).
+// --------------------------------------------------------------------------------
+
+using LeetCode.Algorithms.CountSubmatricesWithTopLeftElementAndSumLessThanK;
+
+namespace LeetCode.Tests.Algorithms.CountSubmatricesWithTopLeftElementAndSumLessThanK;
+
+public abstract class CountSubmatricesWithTopLeftElementAndSumLessThanKTestsBase<T> where T : ICountSubmatricesWithTopLeftElementAndSumLessThanK, new()
+{
+    [TestMethod]
+    [DynamicData(nameof(GetTestData))]
+    public void CountSubmatrices_WithGridAndK_ReturnsNumberOfTopLeftSubmatricesWithSumNotAboveK(int[][] grid, int k, int expectedResult)
+    {
+        // Arrange
+        var solution = new T();
+
+        // Act
+        var actualResult = solution.CountSubmatrices(grid, k);
+
+        // Assert
+        Assert.AreEqual(expectedResult, actualResult);
+    }
+
+    private static IEnumerable<object[]> GetTestData()
+    {
+        yield return [new[] { new[] { 7, 6, 3 }, new[] { 6, 6, 1 } }, 18, 4];
+
+        yield return [new[] { new[] { 7, 2, 9 }, new[] { 1, 5, 0 }, new[] { 2, 6, 6 } }, 20, 6];
+
+        yield return [new[] { new[] { 1 } }, 1, 1];
+
+        yield return [new[] { new[] { 2 } }, 1, 0];
+
+        yield return [new[] { new[] { 0 } }, 5, 1];
+
+        yield return [new[] { new[] { 1, 2 }, new[] { 3, 4 } }, 10, 4];
+
+        yield return [new[] { new[] { 1, 2 }, new[] { 3, 4 } }, 3, 2];
+
+        yield return [new[] { new[] { 1, 2 }, new[] { 3, 4 } }, 1, 1];
+
+        yield return [new[] { new[] { 1, 2 }, new[] { 3, 4 } }, 9, 3];
+
+        yield return [new[] { new[] { 0, 0 }, new[] { 0, 0 } }, 1, 4];
+
+        yield return [new[] { new[] { 5, 5, 5 } }, 10, 2];
+
+        yield return [new[] { new[] { 5 }, new[] { 5 }, new[] { 5 } }, 10, 2];
+
+        yield return [new[] { new[] { 1, 1, 1 }, new[] { 1, 1, 1 }, new[] { 1, 1, 1 } }, 4, 6];
+
+        yield return [new[] { new[] { 1, 1, 1 }, new[] { 1, 1, 1 }, new[] { 1, 1, 1 } }, 9, 9];
+
+        yield return [new[] { new[] { 1000 } }, 1000000000, 1];
+
+        yield return [new[] { new[] { 1000, 1000 }, new[] { 1000, 1000 } }, 999, 0];
+
+        yield return [new[] { new[] { 10, 20 }, new[] { 30, 40 } }, 100, 4];
+
+        yield return [new[] { new[] { 10, 20 }, new[] { 30, 40 } }, 99, 3];
+
+        yield return [new[] { new[] { 1, 2, 3 }, new[] { 4, 5, 6 } }, 12, 5];
+
+        yield return [new[] { new[] { 3, 2 }, new[] { 1, 0 }, new[] { 4, 4 } }, 10, 5];
+
+        yield return [new[] { new[] { 0, 0, 0 }, new[] { 0, 0, 0 } }, 1000000000, 6];
+
+        yield return [new[] { new[] { 1, 2, 3, 4, 5 } }, 6, 3];
+
+        yield return [new[] { new[] { 1 }, new[] { 2 }, new[] { 3 }, new[] { 4 }, new[] { 5 } }, 6, 3];
+
+        yield return [new[] { new[] { 7, 6, 3 }, new[] { 6, 6, 1 } }, 100, 6];
+    }
+}


### PR DESCRIPTION

# Pull Request

## Description

I've implemented a solution for the 'Count Submatrices with Top-Left Element and Sum Less Than k' problem using a prefix sum approach.

## How Has This Been Tested?

I've covered the code with unit tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if appropriate):

<img width="586" height="380" alt="image" src="https://github.com/user-attachments/assets/778a9562-fefe-4ec9-802e-88c2fb4347a0" />