### PR TITLE
Convert CollectionAssert.AreEqual to Assert.AreSequenceEqual

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.3.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="4.3.2" />
+    <PackageVersion Include="MSTest.TestFramework" Version="4.3.2" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="ReportGenerator" Version="5.5.1" />

--- a/source/Tests/LeetCode.Tests/Algorithms/AddToArrayFormOfInteger/AddToArrayFormOfIntegerTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/AddToArrayFormOfInteger/AddToArrayFormOfIntegerTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class AddToArrayFormOfIntegerTestsBase<T> where T : IAddToArrayF
         var actualResult = solution.AddToArrayForm(num, k).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/AllOneDataStructure/AllOneDataStructureTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/AllOneDataStructure/AllOneDataStructureTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class AllOneDataStructureTestsBase<T> where T : IAllOneDataStruc
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<IScenario<IAllOneDataStructure>[]> GetScenarios()

--- a/source/Tests/LeetCode.Tests/Algorithms/ApplyOperationsToAnArray/ApplyOperationsToAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ApplyOperationsToAnArray/ApplyOperationsToAnArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ApplyOperationsToAnArrayTestsBase<T> where T : IApplyOpera
         var actualResult = solution.ApplyOperations(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ArithmeticSubarrays/ArithmeticSubarraysTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ArithmeticSubarrays/ArithmeticSubarraysTestsBase.cs
@@ -35,6 +35,6 @@ public abstract class ArithmeticSubarraysTestsBase<T> where T : IArithmeticSubar
         var actualResult = solution.CheckArithmeticSubarrays(nums, l, r).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/BinaryPrefixDivisibleByFive/BinaryPrefixDivisibleByFiveTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/BinaryPrefixDivisibleByFive/BinaryPrefixDivisibleByFiveTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class BinaryPrefixDivisibleByFiveTestsBase<T> where T : IBinaryP
         var actualResult = solution.PrefixesDivBy5(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/BinaryTreeInorderTraversal/BinaryTreeInorderTraversalTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/BinaryTreeInorderTraversal/BinaryTreeInorderTraversalTestsBase.cs
@@ -30,7 +30,7 @@ public abstract class BinaryTreeInorderTraversalTestsBase<T> where T : IBinaryTr
 
         // Assert
         Assert.IsNotNull(actualResult);
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/BinaryTreePaths/BinaryTreePathsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/BinaryTreePaths/BinaryTreePathsTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class BinaryTreePathsTestsBase<T> where T : IBinaryTreePaths, ne
         var actualResult = solution.BinaryTreePaths(root).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/BinaryTreePostorderTraversal/BinaryTreePostorderTraversalTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/BinaryTreePostorderTraversal/BinaryTreePostorderTraversalTestsBase.cs
@@ -30,7 +30,7 @@ public abstract class BinaryTreePostorderTraversalTestsBase<T> where T : IBinary
 
         // Assert
         Assert.IsNotNull(actualResult);
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/BinaryTreePreorderTraversal/BinaryTreePreorderTraversalTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/BinaryTreePreorderTraversal/BinaryTreePreorderTraversalTestsBase.cs
@@ -30,7 +30,7 @@ public abstract class BinaryTreePreorderTraversalTestsBase<T> where T : IBinaryT
 
         // Assert
         Assert.IsNotNull(actualResult);
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/BuildArrayFromPermutation/BuildArrayFromPermutationTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/BuildArrayFromPermutation/BuildArrayFromPermutationTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class BuildArrayFromPermutationTestsBase<T> where T : IBuildArra
         var actualResult = solution.BuildArray(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ClosestEqualElementQueries/ClosestEqualElementQueriesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ClosestEqualElementQueries/ClosestEqualElementQueriesTestsBase.cs
@@ -37,6 +37,6 @@ public abstract class ClosestEqualElementQueriesTestsBase<T> where T : IClosestE
         var actualResult = solution.SolveQueries(nums, queries).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ClosestPrimeNumbersInRange/ClosestPrimeNumbersInRangeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ClosestPrimeNumbersInRange/ClosestPrimeNumbersInRangeTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class ClosestPrimeNumbersInRangeTestsBase<T> where T : IClosestP
         var actualResult = solution.ClosestPrimes(left, right);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ComputeDecimalRepresentation/ComputeDecimalRepresentationTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ComputeDecimalRepresentation/ComputeDecimalRepresentationTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class ComputeDecimalRepresentationTestsBase<T> where T : IComput
         var actualResult = solution.DecimalRepresentation(n);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ConcatenateArrayWithReverse/ConcatenateArrayWithReverseTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConcatenateArrayWithReverse/ConcatenateArrayWithReverseTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class ConcatenateArrayWithReverseTestsBase<T> where T : IConcate
         var actualResult = solution.ConcatWithReverse(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ConcatenateNonZeroDigitsAndMultiplyBySum2/ConcatenateNonZeroDigitsAndMultiplyBySum2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConcatenateNonZeroDigitsAndMultiplyBySum2/ConcatenateNonZeroDigitsAndMultiplyBySum2TestsBase.cs
@@ -29,7 +29,7 @@ public abstract class ConcatenateNonZeroDigitsAndMultiplyBySum2TestsBase<T> wher
         var actualResult = solution.SumAndMultiply(s, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/ConcatenationOfArray/ConcatenationOfArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConcatenationOfArray/ConcatenationOfArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ConcatenationOfArrayTestsBase<T> where T : IConcatenationO
         var actualResult = solution.GetConcatenation(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ConstructTheMinimumBitwiseArray1/ConstructTheMinimumBitwiseArray1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConstructTheMinimumBitwiseArray1/ConstructTheMinimumBitwiseArray1TestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ConstructTheMinimumBitwiseArray1TestsBase<T> where T : ICo
         var actualResult = solution.MinBitwiseArray(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ConstructTheMinimumBitwiseArray2/ConstructTheMinimumBitwiseArray2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConstructTheMinimumBitwiseArray2/ConstructTheMinimumBitwiseArray2TestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ConstructTheMinimumBitwiseArray2TestsBase<T> where T : ICo
         var actualResult = solution.MinBitwiseArray(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ConvertIntegerToTheSumOfTwoNoZeroIntegers/ConvertIntegerToTheSumOfTwoNoZeroIntegersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConvertIntegerToTheSumOfTwoNoZeroIntegers/ConvertIntegerToTheSumOfTwoNoZeroIntegersTestsBase.cs
@@ -32,6 +32,6 @@ public abstract class ConvertIntegerToTheSumOfTwoNoZeroIntegersTestsBase<T> wher
         var actualResult = solution.GetNoZeroIntegers(n);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ConvertTheTemperature/ConvertTheTemperatureTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConvertTheTemperature/ConvertTheTemperatureTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ConvertTheTemperatureTestsBase<T> where T : IConvertTheTem
         var actualResult = solution.ConvertTemperature(celsius);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/CountIndicesWithOppositeParity/CountIndicesWithOppositeParityTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountIndicesWithOppositeParity/CountIndicesWithOppositeParityTestsBase.cs
@@ -44,6 +44,6 @@ public abstract class CountIndicesWithOppositeParityTestsBase<T> where T : ICoun
         var actualResult = solution.CountOppositeParity(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/CountVowelStringsInRanges/CountVowelStringsInRangesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountVowelStringsInRanges/CountVowelStringsInRangesTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class CountVowelStringsInRangesTestsBase<T> where T : ICountVowe
         var actualResult = solution.VowelStrings(words, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/CountingBits/CountingBitsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CountingBits/CountingBitsTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class CountingBitsTestsBase<T> where T : ICountingBits, new()
         var actualResult = solution.CountBits(n);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/CouponCodeValidator/CouponCodeValidatorTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/CouponCodeValidator/CouponCodeValidatorTestsBase.cs
@@ -39,6 +39,6 @@ public abstract class CouponCodeValidatorTestsBase<T> where T : ICouponCodeValid
         var actualResult = solution.ValidateCoupons(code, businessLine, isActive).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/DecodeXORedArray/DecodeXORedArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DecodeXORedArray/DecodeXORedArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class DecodeXORedArrayTestsBase<T> where T : IDecodeXORedArray, 
         var actualResult = solution.Decode(encoded, first);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/DefuseTheBomb/DefuseTheBombTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DefuseTheBomb/DefuseTheBombTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class DefuseTheBombTestsBase<T> where T : IDefuseTheBomb, new()
         var actualResult = solution.Decrypt(code, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignAnATMMachine/DesignAnATMMachineTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignAnATMMachine/DesignAnATMMachineTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignAnATMMachineTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignAnATMMachine GetSolution();

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignAnOrderedStream/DesignAnOrderedStreamTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignAnOrderedStream/DesignAnOrderedStreamTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignAnOrderedStreamTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignAnOrderedStream GetSolution(int size);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignBrowserHistory/DesignBrowserHistoryTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignBrowserHistory/DesignBrowserHistoryTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignBrowserHistoryTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignBrowserHistory GetSolution(string homepage);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignCircularDeque/DesignCircularDequeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignCircularDeque/DesignCircularDequeTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignCircularDequeTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignCircularDeque GetSolution(int k);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignCircularQueue/DesignCircularQueueTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignCircularQueue/DesignCircularQueueTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignCircularQueueTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignCircularQueue GetSolution(int k);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignFoodRatingSystem/DesignFoodRatingSystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignFoodRatingSystem/DesignFoodRatingSystemTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignFoodRatingSystemTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignFoodRatingSystem GetSolution(string[] foods, string[] cuisines, int[] ratings);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignFrontMiddleBackQueue/DesignFrontMiddleBackQueueTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignFrontMiddleBackQueue/DesignFrontMiddleBackQueueTestsBase.cs
@@ -94,6 +94,6 @@ public abstract class DesignFrontMiddleBackQueueTestsBase<T> where T : IDesignFr
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignHashMap/DesignHashMapTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignHashMap/DesignHashMapTestsBase.cs
@@ -54,7 +54,7 @@ public abstract class DesignHashMapTestsBase<T> where T : IDesignHashMap, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignHashSet/DesignHashSetTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignHashSet/DesignHashSetTestsBase.cs
@@ -54,7 +54,7 @@ public abstract class DesignHashSetTestsBase<T> where T : IDesignHashSet, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignMovieRentalSystem/DesignMovieRentalSystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignMovieRentalSystem/DesignMovieRentalSystemTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignMovieRentalSystemTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignMovieRentalSystem GetSolution(int n, int[][] entries);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignNeighborSumService/DesignNeighborSumServiceTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignNeighborSumService/DesignNeighborSumServiceTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignNeighborSumServiceTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignNeighborSumService GetSolution(int[][] grid);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignNumberContainerSystem/DesignNumberContainerSystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignNumberContainerSystem/DesignNumberContainerSystemTestsBase.cs
@@ -40,7 +40,7 @@ public abstract class DesignNumberContainerSystemTestsBase<T> where T : IDesignN
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<IScenario<IDesignNumberContainerSystem>[]> GetScenarios()

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignParkingSystem/DesignParkingSystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignParkingSystem/DesignParkingSystemTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignParkingSystemTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignParkingSystem GetSolution(int bigCapacity, int mediumCapacity, int smallCapacity);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignSpreadsheet/DesignSpreadsheetTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignSpreadsheet/DesignSpreadsheetTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignSpreadsheetTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignSpreadsheet GetSolution(int rows);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignStackWithIncrementOperation/DesignStackWithIncrementOperationTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignStackWithIncrementOperation/DesignStackWithIncrementOperationTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignStackWithIncrementOperationTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignStackWithIncrementOperation GetSolution(int maxSize);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignTaskManager/DesignTaskManagerTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignTaskManager/DesignTaskManagerTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignTaskManagerTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IDesignTaskManager GetSolution(IList<IList<int>> tasks);

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignTwitter/DesignTwitterTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignTwitter/DesignTwitterTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignTwitterTestsBase<T> where T : IDesignTwitter, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<IScenario<IDesignTwitter>[]> GetScenarios()

--- a/source/Tests/LeetCode.Tests/Algorithms/DesignUndergroundSystem/DesignUndergroundSystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DesignUndergroundSystem/DesignUndergroundSystemTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class DesignUndergroundSystemTestsBase<T> where T : IDesignUnder
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<IScenario<IDesignUndergroundSystem>[]> GetScenarios()

--- a/source/Tests/LeetCode.Tests/Algorithms/DiagonalTraverse/DiagonalTraverseTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DiagonalTraverse/DiagonalTraverseTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class DiagonalTraverseTestsBase<T> where T : IDiagonalTraverse, 
         var actualResult = solution.FindDiagonalOrder(mat);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/DivideStringIntoGroupsOfSizeK/DivideStringIntoGroupsOfSizeKTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DivideStringIntoGroupsOfSizeK/DivideStringIntoGroupsOfSizeKTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class DivideStringIntoGroupsOfSizeKTestsBase<T> where T : IDivid
         var actualResult = solution.DivideString(s, k, fill);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FinalArrayStateAfterKMultiplicationOperations/FinalArrayStateAfterKMultiplicationOperationsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FinalArrayStateAfterKMultiplicationOperations/FinalArrayStateAfterKMultiplicationOperationsTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class FinalArrayStateAfterKMultiplicationOperationsTestsBase<T> 
         var actualResult = solution.GetFinalState(nums, k, multiplier);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FinalPricesWithSpecialDiscountInShop/FinalPricesWithSpecialDiscountInShopTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FinalPricesWithSpecialDiscountInShop/FinalPricesWithSpecialDiscountInShopTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FinalPricesWithSpecialDiscountInShopTestsBase<T> where T :
         var actualResult = solution.FinalPrices(prices);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindAllDuplicatesInAnArray/FindAllDuplicatesInAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindAllDuplicatesInAnArray/FindAllDuplicatesInAnArrayTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FindAllDuplicatesInAnArrayTestsBase<T> where T : IFindAllD
         var actualResult = solution.FindDuplicates(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindAllKDistantIndicesInAnArray/FindAllKDistantIndicesInAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindAllKDistantIndicesInAnArray/FindAllKDistantIndicesInAnArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class FindAllKDistantIndicesInAnArrayTestsBase<T> where T : IFin
         var actualResult = solution.FindKDistantIndices(nums, key, k).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindAllNumbersDisappearedInArray/FindAllNumbersDisappearedInArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindAllNumbersDisappearedInArray/FindAllNumbersDisappearedInArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class FindAllNumbersDisappearedInArrayTestsBase<T> where T : IFi
         var actualResult = solution.FindDisappearedNumbers(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCommonElementsBetweenTwoArrays/FindCommonElementsBetweenTwoArraysTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCommonElementsBetweenTwoArrays/FindCommonElementsBetweenTwoArraysTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FindCommonElementsBetweenTwoArraysTestsBase<T> where T : I
         var actualResult = solution.FindIntersectionValues(nums1, nums2);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindElementsInContaminatedBinaryTree/FindElementsInContaminatedBinaryTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindElementsInContaminatedBinaryTree/FindElementsInContaminatedBinaryTreeTestsBase.cs
@@ -40,7 +40,7 @@ public abstract class FindElementsInContaminatedBinaryTreeTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IFindElementsInContaminatedBinaryTree GetSolution(TreeNode root);

--- a/source/Tests/LeetCode.Tests/Algorithms/FindEventualSafeStates/FindEventualSafeStatesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindEventualSafeStates/FindEventualSafeStatesTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class FindEventualSafeStatesTestsBase<T> where T : IFindEventual
         var actualResult = solution.EventualSafeNodes(graph).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindLargestValueInEachTreeRow/FindLargestValueInEachTreeRowTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindLargestValueInEachTreeRow/FindLargestValueInEachTreeRowTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class FindLargestValueInEachTreeRowTestsBase<T> where T : IFindL
         var actualResult = solution.LargestValues(root).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindMissingElements/FindMissingElementsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindMissingElements/FindMissingElementsTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FindMissingElementsTestsBase<T> where T : IFindMissingElem
         var actualResult = solution.FindMissingElements(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindResultantArrayAfterRemovingAnagrams/FindResultantArrayAfterRemovingAnagramsTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class FindResultantArrayAfterRemovingAnagramsTestsBase<T> where 
         var actualResult = solution.RemoveAnagrams(words).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindSubsequenceOfLengthKWithTheLargestSum/FindSubsequenceOfLengthKWithTheLargestSumTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindSubsequenceOfLengthKWithTheLargestSum/FindSubsequenceOfLengthKWithTheLargestSumTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FindSubsequenceOfLengthKWithTheLargestSumTestsBase<T> wher
         var actualResult = solution.MaxSubsequence(nums, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTargetIndicesAfterSortingArray/FindTargetIndicesAfterSortingArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTargetIndicesAfterSortingArray/FindTargetIndicesAfterSortingArrayTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class FindTargetIndicesAfterSortingArrayTestsBase<T> where T : I
         var actualResult = solution.TargetIndices(nums, target).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTheDegreeOfEachVertex/FindTheDegreeOfEachVertexTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTheDegreeOfEachVertex/FindTheDegreeOfEachVertexTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class FindTheDegreeOfEachVertexTestsBase<T> where T : IFindTheDe
         var actualResult = solution.FindDegrees(matrix);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPoints/FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPointsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPoints/FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPointsTestsBase.cs
@@ -49,6 +49,6 @@ public abstract class FindTheMinimumAndMaximumNumberOfNodesBetweenCriticalPoints
         var actualResult = solution.NodesBetweenCriticalPoints(head);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTheNumberOfDistinctColorsAmongTheBalls/FindTheNumberOfDistinctColorsAmongTheBallsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTheNumberOfDistinctColorsAmongTheBalls/FindTheNumberOfDistinctColorsAmongTheBallsTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class FindTheNumberOfDistinctColorsAmongTheBallsTestsBase<T> whe
         var actualResult = solution.QueryResults(limit, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindTheOriginalArrayOfPrefixXor/FindTheOriginalArrayOfPrefixXorTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindTheOriginalArrayOfPrefixXor/FindTheOriginalArrayOfPrefixXorTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class FindTheOriginalArrayOfPrefixXorTestsBase<T> where T : IFin
         var actualResult = solution.FindArray(pref);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindThePowerOfKSizeSubarrays1/FindThePowerOfKSizeSubarrays1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindThePowerOfKSizeSubarrays1/FindThePowerOfKSizeSubarrays1TestsBase.cs
@@ -42,6 +42,6 @@ public abstract class FindThePowerOfKSizeSubarrays1TestsBase<T> where T : IFindT
         var actualResult = solution.ResultsArray(nums, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindThePrefixCommonArrayOfTwoArrays/FindThePrefixCommonArrayOfTwoArraysTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class FindThePrefixCommonArrayOfTwoArraysTestsBase<T> where T : 
         var actualResult = solution.FindThePrefixCommonArray(a, b);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindWordsContainingCharacter/FindWordsContainingCharacterTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindWordsContainingCharacter/FindWordsContainingCharacterTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FindWordsContainingCharacterTestsBase<T> where T : IFindWo
         var actualResult = solution.FindWordsContaining(words, x).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindingPairsWithCertainSum/FindingPairsWithCertainSumTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindingPairsWithCertainSum/FindingPairsWithCertainSumTestsBase.cs
@@ -50,7 +50,7 @@ public abstract class FindingPairsWithCertainSumTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindingThreeDigitEvenNumbers/FindingThreeDigitEvenNumbersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindingThreeDigitEvenNumbers/FindingThreeDigitEvenNumbersTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FindingThreeDigitEvenNumbersTestsBase<T> where T : IFindin
         var actualResult = solution.FindEvenNumbers(digits);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FizzBuzz/FizzBuzzTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FizzBuzz/FizzBuzzTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class FizzBuzzTestsBase<T> where T : IFizzBuzz, new()
         var actualResult = solution.FizzBuzz(n).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/HeightOfBinaryTreeAfterSubtreeRemovalQueries/HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class HeightOfBinaryTreeAfterSubtreeRemovalQueriesTestsBase<T> w
         var actualResult = solution.TreeQueries(root, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/HowManyNumbersAreSmallerThanTheCurrentNumber/HowManyNumbersAreSmallerThanTheCurrentNumberTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/HowManyNumbersAreSmallerThanTheCurrentNumber/HowManyNumbersAreSmallerThanTheCurrentNumberTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class HowManyNumbersAreSmallerThanTheCurrentNumberTestsBase<T> w
         var actualResult = solution.SmallerNumbersThanCurrent(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ImplementRouter/ImplementRouterTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ImplementRouter/ImplementRouterTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class ImplementRouterTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IImplementRouter GetSolution(int memoryLimit);

--- a/source/Tests/LeetCode.Tests/Algorithms/ImplementTrie/ImplementTrieTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ImplementTrie/ImplementTrieTestsBase.cs
@@ -52,6 +52,6 @@ public abstract class ImplementTrieTestsBase<T> where T : IImplementTrie, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/InsertDeleteGetRandom/InsertDeleteGetRandomTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/InsertDeleteGetRandom/InsertDeleteGetRandomTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class InsertDeleteGetRandomTestsBase<T> where T : IInsertDeleteG
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<IScenario<IInsertDeleteGetRandom>[]> GetScenarios()

--- a/source/Tests/LeetCode.Tests/Algorithms/IntersectionOfMultipleArrays/IntersectionOfMultipleArraysTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/IntersectionOfMultipleArrays/IntersectionOfMultipleArraysTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class IntersectionOfMultipleArraysTestsBase<T> where T : IInters
         var actualResult = solution.Intersection(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/IntervalsBetweenIdenticalElements/IntervalsBetweenIdenticalElementsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/IntervalsBetweenIdenticalElements/IntervalsBetweenIdenticalElementsTestsBase.cs
@@ -47,6 +47,6 @@ public abstract class IntervalsBetweenIdenticalElementsTestsBase<T> where T : II
         var actualResult = solution.GetDistances(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/KeyboardRow/KeyboardRowTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/KeyboardRow/KeyboardRowTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class KeyboardRowTestsBase<T> where T : IKeyboardRow, new()
         var actualResult = solution.FindWords(words);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/KthLargestElementInStream/KthLargestElementInStreamTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/KthLargestElementInStream/KthLargestElementInStreamTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class KthLargestElementInStreamTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IKthLargestElementInStream GetSolution(int k, int[] nums);

--- a/source/Tests/LeetCode.Tests/Algorithms/KthSmallestPrimeFraction/KthSmallestPrimeFractionTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/KthSmallestPrimeFraction/KthSmallestPrimeFractionTestsBase.cs
@@ -48,6 +48,6 @@ public abstract class KthSmallestPrimeFractionTestsBase<T> where T : IKthSmalles
         var actualResult = solution.KthSmallestPrimeFraction(arr, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/LargestDivisibleSubset/LargestDivisibleSubsetTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LargestDivisibleSubset/LargestDivisibleSubsetTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class LargestDivisibleSubsetTestsBase<T> where T : ILargestDivis
         var actualResult = solution.LargestDivisibleSubset(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/LeftAndRightSumDifferences/LeftAndRightSumDifferencesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LeftAndRightSumDifferences/LeftAndRightSumDifferencesTestsBase.cs
@@ -48,6 +48,6 @@ public abstract class LeftAndRightSumDifferencesTestsBase<T> where T : ILeftAndR
         var actualResult = solution.LeftRightDifference(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/LexicographicalNumbers/LexicographicalNumbersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LexicographicalNumbers/LexicographicalNumbersTestsBase.cs
@@ -85,6 +85,6 @@ public abstract class LexicographicalNumbersTestsBase<T> where T : ILexicographi
         var actualResult = solution.LexicalOrder(n).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/LongestUnequalAdjacentGroupsSubsequence1/LongestUnequalAdjacentGroupsSubsequence1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LongestUnequalAdjacentGroupsSubsequence1/LongestUnequalAdjacentGroupsSubsequence1TestsBase.cs
@@ -30,6 +30,6 @@ public abstract class LongestUnequalAdjacentGroupsSubsequence1TestsBase<T> where
         var actualResult = solution.GetLongestSubsequence(words, groups).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MaximizeSumOfAtMostKDistinctElements/MaximizeSumOfAtMostKDistinctElementsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaximizeSumOfAtMostKDistinctElements/MaximizeSumOfAtMostKDistinctElementsTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class MaximizeSumOfAtMostKDistinctElementsTestsBase<T> where T :
         var actualResult = solution.MaxKDistinct(nums, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MaximizeTheNumberOfTargetNodesAfterConnectingTrees1/MaximizeTheNumberOfTargetNodesAfterConnectingTrees1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaximizeTheNumberOfTargetNodesAfterConnectingTrees1/MaximizeTheNumberOfTargetNodesAfterConnectingTrees1TestsBase.cs
@@ -27,7 +27,7 @@ public abstract class MaximizeTheNumberOfTargetNodesAfterConnectingTrees1TestsBa
         var actualResult = solution.MaxTargetNodes(edges1, edges2, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/MaximumXORForEachQuery/MaximumXORForEachQueryTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MaximumXORForEachQuery/MaximumXORForEachQueryTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class MaximumXORForEachQueryTestsBase<T> where T : IMaximumXORFo
         var actualResult = solution.GetMaximumXor(nums, maximumBit);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MergeSortedArray/MergeSortedArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MergeSortedArray/MergeSortedArrayTestsBase.cs
@@ -29,6 +29,6 @@ public abstract class MergeSortedArrayTestsBase<T> where T : IMergeSortedArray, 
         solution.Merge(nums1, m, nums2, n);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, nums1);
+        Assert.AreSequenceEqual(expectedResult, nums1);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumCostToReachEveryPosition/MinimumCostToReachEveryPositionTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumCostToReachEveryPosition/MinimumCostToReachEveryPositionTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class MinimumCostToReachEveryPositionTestsBase<T> where T : IMin
         var actualResult = solution.MinCosts(cost);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberGame/MinimumNumberGameTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberGame/MinimumNumberGameTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class MinimumNumberGameTestsBase<T> where T : IMinimumNumberGame
         var actualResult = solution.NumberGame(cost);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMoveAllBallsToEachBox/MinimumNumberOfOperationsToMoveAllBallsToEachBoxTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumNumberOfOperationsToMoveAllBallsToEachBox/MinimumNumberOfOperationsToMoveAllBallsToEachBoxTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class MinimumNumberOfOperationsToMoveAllBallsToEachBoxTestsBase<
         var actualResult = solution.MinOperations(s);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MostBeautifulItemForEachQuery/MostBeautifulItemForEachQueryTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MostBeautifulItemForEachQuery/MostBeautifulItemForEachQueryTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class MostBeautifulItemForEachQueryTestsBase<T> where T : IMostB
         var actualResult = solution.MaximumBeauty(items, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/MoveZeroes/MoveZeroesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MoveZeroes/MoveZeroesTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class MoveZeroesTestsBase<T> where T : IMoveZeroes, new()
         solution.MoveZeroes(nums);
 
         // Assert
-        CollectionAssert.AreEqual(nums, expectedResult);
+        Assert.AreSequenceEqual(nums, expectedResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MyCalendar1/MyCalendar1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MyCalendar1/MyCalendar1TestsBase.cs
@@ -49,6 +49,6 @@ public abstract class MyCalendar1TestsBase<T> where T : IMyCalendar1, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MyCalendar2/MyCalendar2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MyCalendar2/MyCalendar2TestsBase.cs
@@ -31,6 +31,6 @@ public abstract class MyCalendar2TestsBase<T> where T : IMyCalendar2, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MyCalendar3/MyCalendar3TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MyCalendar3/MyCalendar3TestsBase.cs
@@ -41,7 +41,7 @@ public abstract class MyCalendar3TestsBase<T> where T : IMyCalendar3, new()
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/NaryTreePostorderTraversal/NaryTreePostorderTraversalTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NaryTreePostorderTraversal/NaryTreePostorderTraversalTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class NaryTreePostorderTraversalTestsBase<T> where T : INaryTree
         var actualResult = solution.Postorder(root).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/NaryTreePreorderTraversal/NaryTreePreorderTraversalTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NaryTreePreorderTraversal/NaryTreePreorderTraversalTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class NaryTreePreorderTraversalTestsBase<T> where T : INaryTreeP
 
         var actualResult = solution.Preorder(root).ToArray();
 
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/NextGreaterElement1/NextGreaterElement1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/NextGreaterElement1/NextGreaterElement1TestsBase.cs
@@ -27,6 +27,6 @@ public abstract class NextGreaterElement1TestsBase<T> where T : INextGreaterElem
         var actualResult = solution.NextGreaterElement(nums1, nums2);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/PartitionArrayAccordingToGivenPivot/PartitionArrayAccordingToGivenPivotTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/PartitionArrayAccordingToGivenPivot/PartitionArrayAccordingToGivenPivotTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class PartitionArrayAccordingToGivenPivotTestsBase<T> where T : 
         var actualResult = solution.PivotArray(nums, pivot);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/PartitionLabels/PartitionLabelsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/PartitionLabels/PartitionLabelsTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class PartitionLabelsTestsBase<T> where T : IPartitionLabels, ne
         var actualResult = solution.PartitionLabels(s).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/PascalsTriangle2/PascalsTriangle2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/PascalsTriangle2/PascalsTriangle2TestsBase.cs
@@ -28,6 +28,6 @@ public abstract class PascalsTriangle2TestsBase<T> where T : IPascalsTriangle2, 
         var actualResult = solution.GetRow(rowIndex).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/PlusOne/PlusOneTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/PlusOne/PlusOneTestsBase.cs
@@ -34,6 +34,6 @@ public abstract class PlusOneTestsBase<T> where T : IPlusOne, new()
         var actualResult = solution.PlusOne(digits);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ProductOfArrayExceptSelf/ProductOfArrayExceptSelfTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ProductOfArrayExceptSelf/ProductOfArrayExceptSelfTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ProductOfArrayExceptSelfTestsBase<T> where T : IProductOfA
         var actualResult = solution.ProductExceptSelf(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ProductOfTheLastKNumbers/ProductOfTheLastKNumbersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ProductOfTheLastKNumbers/ProductOfTheLastKNumbersTestsBase.cs
@@ -40,7 +40,7 @@ public abstract class ProductOfTheLastKNumbersTestsBase<T> where T : IProductOfT
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<IScenario<IProductOfTheLastKNumbers>[]> GetScenarios()

--- a/source/Tests/LeetCode.Tests/Algorithms/RandomPickIndex/RandomPickIndexTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RandomPickIndex/RandomPickIndexTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class RandomPickIndexTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IRandomPickIndex GetSolution(int[] nums);

--- a/source/Tests/LeetCode.Tests/Algorithms/RangeProductQueriesOfPowers/RangeProductQueriesOfPowersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RangeProductQueriesOfPowers/RangeProductQueriesOfPowersTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class RangeProductQueriesOfPowersTestsBase<T> where T : IRangePr
         var actualResult = solution.ProductQueries(n, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/RangeSumQueryImmutable/RangeSumQueryImmutableTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RangeSumQueryImmutable/RangeSumQueryImmutableTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class RangeSumQueryImmutableTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IRangeSumQueryImmutable GetSolution(int[] nums);

--- a/source/Tests/LeetCode.Tests/Algorithms/RangeSumQueryMutable/RangeSumQueryMutableTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RangeSumQueryMutable/RangeSumQueryMutableTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class RangeSumQueryMutableTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IRangeSumQueryMutable GetSolution(int[] nums);

--- a/source/Tests/LeetCode.Tests/Algorithms/RankTransformOfAnArray/RankTransformOfAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RankTransformOfAnArray/RankTransformOfAnArrayTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class RankTransformOfAnArrayTestsBase<T> where T : IRankTransfor
         var actualResult = solution.ArrayRankTransform(arr);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RelativeRanks/RelativeRanksTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RelativeRanks/RelativeRanksTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class RelativeRanksTestsBase<T> where T : IRelativeRanks, new()
         var actualResult = solution.FindRelativeRanks(score);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RelativeSortArray/RelativeSortArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RelativeSortArray/RelativeSortArrayTestsBase.cs
@@ -30,6 +30,6 @@ public abstract class RelativeSortArrayTestsBase<T> where T : IRelativeSortArray
         var actualResult = solution.RelativeSortArray(arr1, arr2);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RemoveDuplicatesFromSortedArray2/RemoveDuplicatesFromSortedArray2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RemoveDuplicatesFromSortedArray2/RemoveDuplicatesFromSortedArray2TestsBase.cs
@@ -44,6 +44,6 @@ public abstract class RemoveDuplicatesFromSortedArray2TestsBase<T> where T : IRe
 
         // Assert
         Assert.AreEqual(expectedResult, actualResult);
-        CollectionAssert.AreEqual(expectedNums, nums.Take(expectedResult).ToArray());
+        Assert.AreSequenceEqual(expectedNums, nums.Take(expectedResult).ToArray());
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RemoveSubFoldersFromTheFilesystem/RemoveSubFoldersFromTheFilesystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RemoveSubFoldersFromTheFilesystem/RemoveSubFoldersFromTheFilesystemTestsBase.cs
@@ -29,6 +29,6 @@ public abstract class RemoveSubFoldersFromTheFilesystemTestsBase<T> where T : IR
         var actualResult = solution.RemoveSubfolders(folder).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ReplaceNonCoprimeNumbersInArray/ReplaceNonCoprimeNumbersInArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ReplaceNonCoprimeNumbersInArray/ReplaceNonCoprimeNumbersInArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ReplaceNonCoprimeNumbersInArrayTestsBase<T> where T : IRep
         var actualResult = solution.ReplaceNonCoprimes(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RestoreFinishingOrder/RestoreFinishingOrderTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RestoreFinishingOrder/RestoreFinishingOrderTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class RestoreFinishingOrderTestsBase<T> where T : IRestoreFinish
         var actualResult = solution.RecoverOrder(orders, friends);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RevealCardsInIncreasingOrder/RevealCardsInIncreasingOrderTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RevealCardsInIncreasingOrder/RevealCardsInIncreasingOrderTestsBase.cs
@@ -31,6 +31,6 @@ public abstract class RevealCardsInIncreasingOrderTestsBase<T> where T : IReveal
         var actualResult = solution.DeckRevealedIncreasing(deck);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ReverseString/ReverseStringTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ReverseString/ReverseStringTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class ReverseStringTestsBase<T> where T : IReverseString, new()
         solution.ReverseString(s);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, s);
+        Assert.AreSequenceEqual(expectedResult, s);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RotateArray/RotateArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RotateArray/RotateArrayTestsBase.cs
@@ -32,6 +32,6 @@ public abstract class RotateArrayTestsBase<T> where T : IRotateArray, new()
         var actualResult = nums;
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RowWithMaximumOnes/RowWithMaximumOnesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RowWithMaximumOnes/RowWithMaximumOnesTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class RowWithMaximumOnesTestsBase<T> where T : IRowWithMaximumOn
         var actualResult = solution.RowAndMaximumOnes(mat);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/RunningSumOf1dArray/RunningSumOf1dArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RunningSumOf1dArray/RunningSumOf1dArrayTestsBase.cs
@@ -42,6 +42,6 @@ public abstract class RunningSumOf1dArrayTestsBase<T> where T : IRunningSumOf1dA
         var actualResult = solution.RunningSum(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SelfDividingNumbers/SelfDividingNumbersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SelfDividingNumbers/SelfDividingNumbersTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class SelfDividingNumbersTestsBase<T> where T : ISelfDividingNum
         var actualResult = solution.SelfDividingNumbers(left, right).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SeparateTheDigitsInAnArray/SeparateTheDigitsInAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SeparateTheDigitsInAnArray/SeparateTheDigitsInAnArrayTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class SeparateTheDigitsInAnArrayTestsBase<T> where T : ISeparate
         var actualResult = solution.SeparateDigits(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SetMismatch/SetMismatchTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SetMismatch/SetMismatchTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class SetMismatchTestsBase<T> where T : ISetMismatch, new()
         var actualResult = solution.FindErrorNums(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ShortestDistanceAfterRoadAdditionQueries1/ShortestDistanceAfterRoadAdditionQueries1TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ShortestDistanceAfterRoadAdditionQueries1/ShortestDistanceAfterRoadAdditionQueries1TestsBase.cs
@@ -26,7 +26,7 @@ public abstract class ShortestDistanceAfterRoadAdditionQueries1TestsBase<T> wher
         var actualResult = solution.ShortestDistanceAfterQueries(n, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/ShuffleTheArray/ShuffleTheArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ShuffleTheArray/ShuffleTheArrayTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class ShuffleTheArrayTestsBase<T> where T : IShuffleTheArray, ne
         var actualResult = solution.Shuffle(nums, n);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SimpleBankSystem/SimpleBankSystemTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SimpleBankSystem/SimpleBankSystemTestsBase.cs
@@ -39,7 +39,7 @@ public abstract class SimpleBankSystemTestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract ISimpleBankSystem GetSolution(long[] balance);

--- a/source/Tests/LeetCode.Tests/Algorithms/SmallestPairWithDifferentFrequencies/SmallestPairWithDifferentFrequenciesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SmallestPairWithDifferentFrequencies/SmallestPairWithDifferentFrequenciesTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class SmallestPairWithDifferentFrequenciesTestsBase<T> where T :
         var actualResult = solution.MinDistinctFreqPair(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SmallestRangeCoveringElementsFromKLists/SmallestRangeCoveringElementsFromKListsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SmallestRangeCoveringElementsFromKLists/SmallestRangeCoveringElementsFromKListsTestsBase.cs
@@ -28,7 +28,7 @@ public abstract class SmallestRangeCoveringElementsFromKListsTestsBase<T> where 
         var actualResult = solution.SmallestRange(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SortAnArray/SortAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortAnArray/SortAnArrayTestsBase.cs
@@ -43,6 +43,6 @@ public abstract class SortAnArrayTestsBase<T> where T : ISortAnArray, new()
         solution.SortArray(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, nums);
+        Assert.AreSequenceEqual(expectedResult, nums);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SortArrayByIncreasingFrequency/SortArrayByIncreasingFrequencyTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortArrayByIncreasingFrequency/SortArrayByIncreasingFrequencyTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class SortArrayByIncreasingFrequencyTestsBase<T> where T : ISort
         var actualResult = solution.FrequencySort(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SortColors/SortColorsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortColors/SortColorsTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class SortColorsTestsBase<T> where T : ISortColors, new()
         solution.SortColors(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, nums);
+        Assert.AreSequenceEqual(expectedResult, nums);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SortTheJumbledNumbers/SortTheJumbledNumbersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortTheJumbledNumbers/SortTheJumbledNumbersTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class SortTheJumbledNumbersTestsBase<T> where T : ISortTheJumble
         var actualResult = solution.SortJumbled(mapping, nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SortThePeople/SortThePeopleTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortThePeople/SortThePeopleTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class SortThePeopleTestsBase<T> where T : ISortThePeople, new()
         var actualResult = solution.SortPeople(names, heights);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SpecialArray2/SpecialArray2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SpecialArray2/SpecialArray2TestsBase.cs
@@ -26,7 +26,7 @@ public abstract class SpecialArray2TestsBase<T> where T : ISpecialArray2, new()
         var actualResult = solution.IsArraySpecial(nums, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix/SpiralMatrixTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix/SpiralMatrixTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class SpiralMatrixTestsBase<T> where T : ISpiralMatrix, new()
         var actualResult = solution.SpiralOrder(matrix).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SplitStringsBySeparator/SplitStringsBySeparatorTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SplitStringsBySeparator/SplitStringsBySeparatorTestsBase.cs
@@ -31,6 +31,6 @@ public abstract class SplitStringsBySeparatorTestsBase<T> where T : ISplitString
         var actualResult = solution.SplitWordsBySeparator(words, separator).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SquaresOfSortedArray/SquaresOfSortedArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SquaresOfSortedArray/SquaresOfSortedArrayTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class SquaresOfSortedArrayTestsBase<T> where T : ISquaresOfSorte
         var actualResult = solution.SortedSquares(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/StringMatchingInAnArray/StringMatchingInAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/StringMatchingInAnArray/StringMatchingInAnArrayTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class StringMatchingInAnArrayTestsBase<T> where T : IStringMatch
         var actualResult = solution.StringMatching(words).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SumOfDistances/SumOfDistancesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SumOfDistances/SumOfDistancesTestsBase.cs
@@ -36,6 +36,6 @@ public abstract class SumOfDistancesTestsBase<T> where T : ISumOfDistances, new(
         var actualResult = solution.Distance(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SumOfDistancesInTree/SumOfDistancesInTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SumOfDistancesInTree/SumOfDistancesInTreeTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class SumOfDistancesInTreeTestsBase<T> where T : ISumOfDistances
         var actualResult = solution.SumOfDistancesInTree(n, edges);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SumOfPrefixScoresOfStrings/SumOfPrefixScoresOfStringsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SumOfPrefixScoresOfStrings/SumOfPrefixScoresOfStringsTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class SumOfPrefixScoresOfStringsTestsBase<T> where T : ISumOfPre
         var actualResult = solution.SumPrefixScores(words);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SummaryRanges/SummaryRangesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SummaryRanges/SummaryRangesTestsBase.cs
@@ -43,6 +43,6 @@ public abstract class SummaryRangesTestsBase<T> where T : ISummaryRanges, new()
         var actualResult = solution.SummaryRanges(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ToggleLightBulbs/ToggleLightBulbsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ToggleLightBulbs/ToggleLightBulbsTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class ToggleLightBulbsTestsBase<T> where T : IToggleLightBulbs, 
         var actualResult = solution.ToggleLightBulbs(bulbs).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/TransformArrayByParity/TransformArrayByParityTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TransformArrayByParity/TransformArrayByParityTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class TransformArrayByParityTestsBase<T> where T : ITransformArr
         var actualResult = solution.TransformArray(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/TransformedArray/TransformedArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TransformedArray/TransformedArrayTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class TransformedArrayTestsBase<T> where T : ITransformedArray, 
         var actualResult = solution.ConstructTransformedArray(nums);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/TwoSum/TwoSumTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TwoSum/TwoSumTestsBase.cs
@@ -41,6 +41,6 @@ public abstract class TwoSumTestsBase<T> where T : ITwoSum, new()
         var actualResult = solution.TwoSum(nums, target);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/TwoSum2InputArrayIsSorted/TwoSum2InputArrayIsSortedTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TwoSum2InputArrayIsSorted/TwoSum2InputArrayIsSortedTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class TwoSum2InputArrayIsSortedTestsBase<T> where T : ITwoSum2In
         var actualResult = solution.TwoSum(numbers, target);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/UncommonWordsFromTwoSentences/UncommonWordsFromTwoSentencesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/UncommonWordsFromTwoSentences/UncommonWordsFromTwoSentencesTestsBase.cs
@@ -29,6 +29,6 @@ public abstract class UncommonWordsFromTwoSentencesTestsBase<T> where T : IUncom
         var actualResult = solution.UncommonFromSentences(s1, s2);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ValidElementsInAnArray/ValidElementsInAnArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ValidElementsInAnArray/ValidElementsInAnArrayTestsBase.cs
@@ -45,6 +45,6 @@ public abstract class ValidElementsInAnArrayTestsBase<T> where T : IValidElement
         var actualResult = solution.FindValidElements(nums).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/VowelSpellchecker/VowelSpellcheckerTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/VowelSpellchecker/VowelSpellcheckerTestsBase.cs
@@ -30,6 +30,6 @@ public abstract class VowelSpellcheckerTestsBase<T> where T : IVowelSpellchecker
         var actualResult = solution.Spellchecker(wordlist, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/WalkingRobotSimulation2/WalkingRobotSimulation2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/WalkingRobotSimulation2/WalkingRobotSimulation2TestsBase.cs
@@ -11,7 +11,6 @@
 
 using LeetCode.Algorithms.WalkingRobotSimulation2;
 using LeetCode.Tests.Base.Scenarios;
-using System.Collections;
 
 namespace LeetCode.Tests.Algorithms.WalkingRobotSimulation2;
 
@@ -40,7 +39,7 @@ public abstract class WalkingRobotSimulation2TestsBase
         }
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult, OperationResultComparer.Instance);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IWalkingRobotSimulation2 CreateSolution(int width, int height);
@@ -304,16 +303,6 @@ public abstract class WalkingRobotSimulation2TestsBase
 
         public IOperation<IWalkingRobotSimulation2>[] Operations { get; }
         public IOperationResult[] OperationResults { get; }
-    }
-
-    private sealed class OperationResultComparer : IComparer
-    {
-        public static readonly OperationResultComparer Instance = new();
-
-        public int Compare(object? x, object? y)
-        {
-            return Equals(x, y) ? 0 : -1;
-        }
     }
 
     private sealed class StepOperation : IOperation<IWalkingRobotSimulation2>

--- a/source/Tests/LeetCode.Tests/Algorithms/WordSubsets/WordSubsetsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/WordSubsets/WordSubsetsTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class WordSubsetsTestsBase<T> where T : IWordSubsets, new()
         var actualResult = solution.WordSubsets(words1, words2).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/WordsWithinTwoEditsOfDictionary/WordsWithinTwoEditsOfDictionaryTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/WordsWithinTwoEditsOfDictionary/WordsWithinTwoEditsOfDictionaryTestsBase.cs
@@ -46,6 +46,6 @@ public abstract class WordsWithinTwoEditsOfDictionaryTestsBase<T> where T : IWor
         var actualResult = solution.TwoEditWords(queries, words).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/XORQueriesOfSubarray/XORQueriesOfSubarrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/XORQueriesOfSubarray/XORQueriesOfSubarrayTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class XORQueriesOfSubarrayTestsBase<T> where T : IXORQueriesOfSu
         var actualResult = solution.XorQueries(arr, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/ZigzagGridTraversalWithSkip/ZigzagGridTraversalWithSkipTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ZigzagGridTraversalWithSkip/ZigzagGridTraversalWithSkipTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class ZigzagGridTraversalWithSkipTestsBase<T> where T : IZigzagG
         var actualResult = solution.ZigzagTraversal(grid).ToArray();
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Concurrency/FizzBuzzMultithreaded/FizzBuzzMultithreadedTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Concurrency/FizzBuzzMultithreaded/FizzBuzzMultithreadedTestsBase.cs
@@ -38,7 +38,7 @@ public abstract class FizzBuzzMultithreadedTestsBase
         await Task.WhenAll(tasks);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult);
     }
 
     protected abstract IFizzBuzzMultithreaded GetSolution(int n);


### PR DESCRIPTION
# Pull Request

## Description

I've converted the CollectionAssert.AreEqual to Assert.AreSequenceEqual

## How Has This Been Tested?

I've verified that all tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works