### PR TITLE
Convert CollectionAssert.AreEquivalent to Assert.AreEquivalent

### DIFF
--- a/source/Tests/LeetCode.Tests/Algorithms/ConstructProductMatrix/ConstructProductMatrixTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ConstructProductMatrix/ConstructProductMatrixTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.ConstructProductMatrix;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.ConstructProductMatrix;
 
@@ -26,7 +27,7 @@ public abstract class ConstructProductMatrixTestsBase<T> where T : IConstructPro
         var actualResult = solution.ConstructProductMatrix(grid);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/DifferentWaysToAddParentheses/DifferentWaysToAddParenthesesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DifferentWaysToAddParentheses/DifferentWaysToAddParenthesesTestsBase.cs
@@ -76,6 +76,6 @@ public abstract class DifferentWaysToAddParenthesesTestsBase<T> where T : IDiffe
         var actualResult = solution.DiffWaysToCompute(expression).ToArray();
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/DivideArrayIntoArraysWithMaxDifference/DivideArrayIntoArraysWithMaxDifferenceTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/DivideArrayIntoArraysWithMaxDifference/DivideArrayIntoArraysWithMaxDifferenceTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.DivideArrayIntoArraysWithMaxDifference;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.DivideArrayIntoArraysWithMaxDifference;
 
@@ -26,7 +27,7 @@ public abstract class DivideArrayIntoArraysWithMaxDifferenceTestsBase<T> where T
         var actualResult = solution.DivideArray(nums, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindAllGroupOfFarmland/FindAllGroupOfFarmlandTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindAllGroupOfFarmland/FindAllGroupOfFarmlandTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.FindAllGroupOfFarmland;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.FindAllGroupOfFarmland;
 
@@ -26,7 +27,7 @@ public abstract class FindAllGroupOfFarmlandTestsBase<T> where T : IFindAllGroup
         var actualResult = solution.FindFarmland(land);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindCommonCharacters/FindCommonCharactersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindCommonCharacters/FindCommonCharactersTestsBase.cs
@@ -34,6 +34,6 @@ public abstract class FindCommonCharactersTestsBase<T> where T : IFindCommonChar
         var actualResult = solution.CommonChars(words);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult.ToList(), actualResult.ToList());
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindMissingAndRepeatedValues/FindMissingAndRepeatedValuesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindMissingAndRepeatedValues/FindMissingAndRepeatedValuesTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class FindMissingAndRepeatedValuesTestsBase<T> where T : IFindMi
         var actualResult = solution.FindMissingAndRepeatedValues(grid);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindMissingObservations/FindMissingObservationsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindMissingObservations/FindMissingObservationsTestsBase.cs
@@ -34,6 +34,6 @@ public abstract class FindMissingObservationsTestsBase<T> where T : IFindMissing
         var actualResult = solution.MissingRolls(rolls, mean, n);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FindModeInBinarySearchTree/FindModeInBinarySearchTreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindModeInBinarySearchTree/FindModeInBinarySearchTreeTestsBase.cs
@@ -29,7 +29,7 @@ public abstract class FindModeInBinarySearchTreeTestsBase<T> where T : IFindMode
         var actualResult = solution.FindMode(root);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FindNUniqueIntegersSumUpToZero/FindNUniqueIntegersSumUpToZeroTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FindNUniqueIntegersSumUpToZero/FindNUniqueIntegersSumUpToZeroTestsBase.cs
@@ -30,6 +30,6 @@ public abstract class FindNUniqueIntegersSumUpToZeroTestsBase<T> where T : IFind
         var actualResult = solution.SumZero(n);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/FlipSquareSubmatrixVertically/FlipSquareSubmatrixVerticallyTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FlipSquareSubmatrixVertically/FlipSquareSubmatrixVerticallyTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.FlipSquareSubmatrixVertically;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.FlipSquareSubmatrixVertically;
 
@@ -31,7 +32,7 @@ public abstract class FlipSquareSubmatrixVerticallyTestsBase<T> where T : IFlipS
         var actualResult = solution.ReverseSubmatrix(grid, x, y, k);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FlippingAnImage/FlippingAnImageTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FlippingAnImage/FlippingAnImageTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.FlippingAnImage;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.FlippingAnImage;
 
@@ -26,7 +27,7 @@ public abstract class FlippingAnImageTestsBase<T> where T : IFlippingAnImage, ne
         var actualResult = solution.FlipAndInvertImage(image);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/FloodFill/FloodFillTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/FloodFill/FloodFillTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.FloodFill;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.FloodFill;
 
@@ -26,7 +27,7 @@ public abstract class FloodFillTestsBase<T> where T : IFloodFill, new()
         var actualResult = solution.FloodFill(image, sr, sc, color);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/IncrementSubmatricesByOne/IncrementSubmatricesByOneTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/IncrementSubmatricesByOne/IncrementSubmatricesByOneTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.IncrementSubmatricesByOne;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.IncrementSubmatricesByOne;
 
@@ -26,7 +27,7 @@ public abstract class IncrementSubmatricesByOneTestsBase<T> where T : IIncrement
         var actualResult = solution.RangeAddQueries(n, queries);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/InsertInterval/InsertIntervalTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/InsertInterval/InsertIntervalTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.InsertInterval;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.InsertInterval;
 
@@ -26,7 +27,7 @@ public abstract class InsertIntervalTestsBase<T> where T : IInsertInterval, new(
         var actualResult = solution.Insert(intervals, newInterval);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/IntersectionOfTwoArrays/IntersectionOfTwoArraysTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/IntersectionOfTwoArrays/IntersectionOfTwoArraysTestsBase.cs
@@ -27,6 +27,6 @@ public abstract class IntersectionOfTwoArraysTestsBase<T> where T : IIntersectio
         var actualResult = solution.Intersection(nums1, nums2);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/IntersectionOfTwoArrays2/IntersectionOfTwoArrays2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/IntersectionOfTwoArrays2/IntersectionOfTwoArrays2TestsBase.cs
@@ -27,6 +27,6 @@ public abstract class IntersectionOfTwoArrays2TestsBase<T> where T : IIntersecti
         var actualResult = solution.Intersect(nums1, nums2);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/LuckyNumbersInMatrix/LuckyNumbersInMatrixTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/LuckyNumbersInMatrix/LuckyNumbersInMatrixTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class LuckyNumbersInMatrixTestsBase<T> where T : ILuckyNumbersIn
         var actualResult = solution.LuckyNumbers(matrix).ToArray();
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/MajorityElement2/MajorityElement2TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MajorityElement2/MajorityElement2TestsBase.cs
@@ -49,6 +49,6 @@ public abstract class MajorityElement2TestsBase<T> where T : IMajorityElement2, 
         var actualResult = solution.MajorityElement(nums);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult.ToArray());
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MajorityFrequencyCharacters/MajorityFrequencyCharactersTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MajorityFrequencyCharacters/MajorityFrequencyCharactersTestsBase.cs
@@ -43,6 +43,6 @@ public abstract class MajorityFrequencyCharactersTestsBase<T> where T : IMajorit
         var actualResult = solution.MajorityFrequencyGroup(s);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult.ToCharArray(), actualResult.ToCharArray());
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/MinimumHeightTrees/MinimumHeightTreesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/MinimumHeightTrees/MinimumHeightTreesTestsBase.cs
@@ -26,7 +26,7 @@ public abstract class MinimumHeightTreesTestsBase<T> where T : IMinimumHeightTre
         var actualResult = solution.FindMinHeightTrees(n, edges).ToArray();
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/ModifyTheMatrix/ModifyTheMatrixTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ModifyTheMatrix/ModifyTheMatrixTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.ModifyTheMatrix;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.ModifyTheMatrix;
 
@@ -26,7 +27,7 @@ public abstract class ModifyTheMatrixTestsBase<T> where T : IModifyTheMatrix, ne
         var actualResult = solution.ModifiedMatrix(matrix);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/RemoveDuplicatesFromSortedArray/RemoveDuplicatesFromSortedArrayTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RemoveDuplicatesFromSortedArray/RemoveDuplicatesFromSortedArrayTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class RemoveDuplicatesFromSortedArrayTestsBase<T> where T : IRem
 
         // Assert
         Assert.AreEqual(expectedResult, actualResult);
-        CollectionAssert.AreEquivalent(expectedNums, nums.Take(actualResult).ToArray());
+        Assert.AreSequenceEqual(expectedNums, nums.Take(actualResult), SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RemoveElement/RemoveElementTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RemoveElement/RemoveElementTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class RemoveElementTestsBase<T> where T : IRemoveElement, new()
 
         // Assert
         Assert.AreEqual(expectedResult, actualResult);
-        CollectionAssert.AreEquivalent(expectedNums, nums.Take(actualResult).ToArray());
+        Assert.AreSequenceEqual(expectedNums, nums.Take(actualResult), SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/RotatingTheBox/RotatingTheBoxTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/RotatingTheBox/RotatingTheBoxTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.RotatingTheBox;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.RotatingTheBox;
 
@@ -26,7 +27,7 @@ public abstract class RotatingTheBoxTestsBase<T> where T : IRotatingTheBox, new(
         var actualResult = solution.RotateTheBox(box);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SetMatrixZeroes/SetMatrixZeroesTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SetMatrixZeroes/SetMatrixZeroesTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.SetMatrixZeroes;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.SetMatrixZeroes;
 
@@ -26,7 +27,7 @@ public abstract class SetMatrixZeroesTestsBase<T> where T : ISetMatrixZeroes, ne
         solution.SetZeroes(matrix);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, matrix);
+        NestedCollectionAssert.AreEqual(expectedResult, matrix);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SingleNumber3/SingleNumber3TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SingleNumber3/SingleNumber3TestsBase.cs
@@ -28,6 +28,6 @@ public abstract class SingleNumber3TestsBase<T> where T : ISingleNumber3, new()
         var actualResult = solution.SingleNumber(nums);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/SortMatrixByDiagonals/SortMatrixByDiagonalsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortMatrixByDiagonals/SortMatrixByDiagonalsTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.SortMatrixByDiagonals;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.SortMatrixByDiagonals;
 
@@ -26,7 +27,7 @@ public abstract class SortMatrixByDiagonalsTestsBase<T> where T : ISortMatrixByD
         var actualResult = solution.SortMatrix(grid);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SortTheMatrixDiagonally/SortTheMatrixDiagonallyTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SortTheMatrixDiagonally/SortTheMatrixDiagonallyTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.SortTheMatrixDiagonally;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.SortTheMatrixDiagonally;
 
@@ -26,7 +27,7 @@ public abstract class SortTheMatrixDiagonallyTestsBase<T> where T : ISortTheMatr
         var actualResult = solution.DiagonalSort(mat);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix3/SpiralMatrix3TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix3/SpiralMatrix3TestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.SpiralMatrix3;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.SpiralMatrix3;
 
@@ -31,7 +32,7 @@ public abstract class SpiralMatrix3TestsBase<T> where T : ISpiralMatrix3, new()
         var actualResult = solution.SpiralMatrixIII(rows, cols, rStart, cStart);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix4/SpiralMatrix4TestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/SpiralMatrix4/SpiralMatrix4TestsBase.cs
@@ -11,6 +11,7 @@
 
 using LeetCode.Algorithms.SpiralMatrix4;
 using LeetCode.Core.Models;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.SpiralMatrix4;
 
@@ -33,7 +34,7 @@ public abstract class SpiralMatrix4TestsBase<T> where T : ISpiralMatrix4, new()
         var actualResult = solution.SpiralMatrix(m, n, head);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/TheTwoSneakyNumbersOfDigitville/TheTwoSneakyNumbersOfDigitvilleTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TheTwoSneakyNumbersOfDigitville/TheTwoSneakyNumbersOfDigitvilleTestsBase.cs
@@ -28,6 +28,6 @@ public abstract class TheTwoSneakyNumbersOfDigitvilleTestsBase<T> where T : IThe
         var actualResult = solution.GetSneakyNumbers(nums);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/TopKFrequentElements/TopKFrequentElementsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TopKFrequentElements/TopKFrequentElementsTestsBase.cs
@@ -49,6 +49,6 @@ public abstract class TopKFrequentElementsTestsBase<T> where T : ITopKFrequentEl
         var actualResult = solution.TopKFrequent(nums, k);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult);
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/TwoOutOfThree/TwoOutOfThreeTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/TwoOutOfThree/TwoOutOfThreeTestsBase.cs
@@ -46,6 +46,6 @@ public abstract class TwoOutOfThreeTestsBase<T> where T : ITwoOutOfThree, new()
         var actualResult = solution.TwoOutOfThree(nums1, nums2, nums3);
 
         // Assert
-        CollectionAssert.AreEquivalent(expectedResult, actualResult.ToList());
+        Assert.AreSequenceEqual(expectedResult, actualResult, SequenceOrder.InAnyOrder);
     }
 }

--- a/source/Tests/LeetCode.Tests/Algorithms/ValidArrangementOfPairs/ValidArrangementOfPairsTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ValidArrangementOfPairs/ValidArrangementOfPairsTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.ValidArrangementOfPairs;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.ValidArrangementOfPairs;
 
@@ -26,7 +27,7 @@ public abstract class ValidArrangementOfPairsTestsBase<T> where T : IValidArrang
         var actualResult = solution.ValidArrangement(pairs);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()

--- a/source/Tests/LeetCode.Tests/Algorithms/ZeroOneMatrix/ZeroOneMatrixTestsBase.cs
+++ b/source/Tests/LeetCode.Tests/Algorithms/ZeroOneMatrix/ZeroOneMatrixTestsBase.cs
@@ -10,6 +10,7 @@
 // --------------------------------------------------------------------------------
 
 using LeetCode.Algorithms.ZeroOneMatrix;
+using LeetCode.Tests.Base.Extensions;
 
 namespace LeetCode.Tests.Algorithms.ZeroOneMatrix;
 
@@ -26,7 +27,7 @@ public abstract class ZeroOneMatrixTestsBase<T> where T : IZeroOneMatrix, new()
         var actualResult = solution.UpdateMatrix(mat);
 
         // Assert
-        CollectionAssert.AreEqual(expectedResult, actualResult);
+        NestedCollectionAssert.AreEqual(expectedResult, actualResult);
     }
 
     private static IEnumerable<object[]> GetTestData()


### PR DESCRIPTION
# Pull Request

## Description

I've converted the Convert CollectionAssert.AreEquivalent to Assert.AreEquivalent

## How Has This Been Tested?

I've verified that all tests pass.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works